### PR TITLE
DBExport improvements

### DIFF
--- a/Assets/_Code/Data/Job/JobDesc.Tasks.cs
+++ b/Assets/_Code/Data/Job/JobDesc.Tasks.cs
@@ -52,6 +52,15 @@ namespace Aqua
             return ArrayUtils.MapFrom(m_Tasks, (t) => t.Id.ToDebugString());
         }
 
+        public SerializedHash32[] EditorReqTaskIds(StringHash32 id) {
+            foreach(var task in m_Tasks) {
+                if (task.Id == id) {
+                    return task.PrerequisiteTaskIds;
+                }
+            }
+            return null;
+        }
+
         internal JobTaskCategory EditorTaskCategory(StringHash32 id) {
             foreach(var task in m_Tasks) {
                 if (task.Id == id) {

--- a/Assets/_Code/Data/Job/JobDesc.Tasks.cs
+++ b/Assets/_Code/Data/Job/JobDesc.Tasks.cs
@@ -35,6 +35,8 @@ namespace Aqua
             public SerializedHash32 Id;
             public TextId LabelId;
             public JobTaskCategory Category;
+            [SerializeField, Range(0, 3)] public int TaskComplexity;
+            [SerializeField, Range(0, 3)] public int  ScaffoldingComplexity;
             
             public JobStep[] Steps = null;
 
@@ -57,6 +59,24 @@ namespace Aqua
                 }
             }
             return JobTaskCategory.Unknown;
+        }
+
+        internal int EditorTaskComplexity(StringHash32 id) {
+            foreach(var task in m_Tasks){
+                if (task.Id == id) {
+                    return task.TaskComplexity;
+                }
+            }
+            return 0;
+        }
+
+        internal int EditorTaskScaffoldingComplexity(StringHash32 id) {
+            foreach(var task in m_Tasks){
+                if (task.Id == id) {
+                    return task.ScaffoldingComplexity;
+                }
+            }
+            return 0;
         }
 
         int IBaked.Order { get { return 16; }}

--- a/Assets/_Code/Data/Job/JobDesc.Tasks.cs
+++ b/Assets/_Code/Data/Job/JobDesc.Tasks.cs
@@ -52,12 +52,14 @@ namespace Aqua
             return ArrayUtils.MapFrom(m_Tasks, (t) => t.Id.ToDebugString());
         }
 
-        public SerializedHash32[] EditorReqTaskIds(StringHash32 id) {
+        public string[] EditorReqTaskIds(StringHash32 id) {
             foreach(var task in m_Tasks) {
                 if (task.Id == id) {
-                    return task.PrerequisiteTaskIds;
+                    // return array of prereq task IDs from the given task ID
+                    return ArrayUtils.MapFrom(task.PrerequisiteTaskIds, (t) => t.ToDebugString());
                 }
             }
+            Log.Error("[JobDesc] Task '{0}' not found in job '{1}', name, id.ToDebugString()");
             return null;
         }
 
@@ -86,6 +88,15 @@ namespace Aqua
                 }
             }
             return 0;
+        }
+
+        public JobStep[] EditorJobTaskSteps(StringHash32 id) {
+            foreach(var task in m_Tasks) {
+                if (task.Id == id) {
+                    return task.Steps;
+                }
+            }
+            return null;
         }
 
         int IBaked.Order { get { return 16; }}

--- a/Assets/_Code/Data/Job/JobDesc.cs
+++ b/Assets/_Code/Data/Job/JobDesc.cs
@@ -22,6 +22,7 @@ namespace Aqua
         [SerializeField] private TextId m_DescId = default;
         [SerializeField] private TextId m_DescShortId = default;
 
+        [SerializeField, Range(0, 3)] private int m_TopicComplexity = 0;
         [SerializeField, Range(0, 5)] private int m_ExperimentDifficulty = 0;
         [SerializeField, Range(0, 5)] private int m_ModelingDifficulty = 0;
         [SerializeField, Range(0, 5)] private int m_ArgumentationDifficulty = 0;
@@ -81,6 +82,7 @@ namespace Aqua
         public ListSlice<StringHash32> RequiredUpgrades() { return m_PrereqUpgrades; }
         public StringSlice RequiredConditions() { return m_PrereqConditions; }
         public int RequiredExp() { return m_PrereqExp; }
+        public int TopicComplexity() {return m_TopicComplexity; }
         public StringHash32 RequiredBestiaryEntry() { return m_PrereqBestiaryEntry; }
         public StringHash32 RequiredScanId() { return m_PrereqScanId; }
 

--- a/Assets/_Code/Data/Job/JobTask.cs
+++ b/Assets/_Code/Data/Job/JobTask.cs
@@ -11,8 +11,6 @@ namespace Aqua
         public ushort Index;
         
         public TextId LabelId;
-        public int TaskComplexity;
-        public int ScaffoldingComplexity;
         
         public JobStep[] Steps;
         public ushort[] PrerequisiteTaskIndices;

--- a/Assets/_Code/Data/Job/JobTask.cs
+++ b/Assets/_Code/Data/Job/JobTask.cs
@@ -11,6 +11,8 @@ namespace Aqua
         public ushort Index;
         
         public TextId LabelId;
+        // public int TaskComplexity;
+        // public int ScaffoldingComplexity;
         
         public JobStep[] Steps;
         public ushort[] PrerequisiteTaskIndices;

--- a/Assets/_Code/Data/Job/JobTask.cs
+++ b/Assets/_Code/Data/Job/JobTask.cs
@@ -11,8 +11,8 @@ namespace Aqua
         public ushort Index;
         
         public TextId LabelId;
-        // public int TaskComplexity;
-        // public int ScaffoldingComplexity;
+        public int TaskComplexity;
+        public int ScaffoldingComplexity;
         
         public JobStep[] Steps;
         public ushort[] PrerequisiteTaskIndices;

--- a/Assets/_Code/_Editor/JobDescEditor.cs
+++ b/Assets/_Code/_Editor/JobDescEditor.cs
@@ -23,6 +23,7 @@ namespace Aqua.Editor
         private SerializedProperty m_DescIdProperty;
         private SerializedProperty m_DescShortIdProperty;
 
+        private SerializedProperty m_TopicComplexityProperty;
         private SerializedProperty m_ExperimentDifficultyProperty;
         private SerializedProperty m_ModelingDifficultyProperty;
         private SerializedProperty m_ArgumentationDifficultyProperty;
@@ -91,6 +92,7 @@ namespace Aqua.Editor
             m_CategoryProperty = serializedObject.FindProperty("m_Category");
             m_FlagsProperty = serializedObject.FindProperty("m_Flags");
             m_NameIdProperty = serializedObject.FindProperty("m_NameId");
+            m_TopicComplexityProperty = serializedObject.FindProperty("m_TopicComplexity");
             m_PosterIdProperty = serializedObject.FindProperty("m_PosterId");
             m_DescIdProperty = serializedObject.FindProperty("m_DescId");
             m_DescShortIdProperty = serializedObject.FindProperty("m_DescShortId");
@@ -152,6 +154,7 @@ namespace Aqua.Editor
             EditorGUILayout.PropertyField(m_CategoryProperty);
             EditorGUILayout.PropertyField(m_FlagsProperty);
             EditorGUILayout.PropertyField(m_StationIdProperty);
+            EditorGUILayout.PropertyField(m_TopicComplexityProperty);
 
             if (Section("Text", ref m_TextExpanded)) {
                 EditorGUILayout.PropertyField(m_NameIdProperty);
@@ -235,7 +238,6 @@ namespace Aqua.Editor
 
                 m_ExtraAssetsList.DoLayoutList();
             }
-
             if (Section("Difficulty Ratings", ref m_DifficultyExpanded)) {
                 EditorGUILayout.PropertyField(m_ExperimentDifficultyProperty);
                 EditorGUILayout.PropertyField(m_ModelingDifficultyProperty);

--- a/Assets/_Code/_Editor/JobDescEditor.cs
+++ b/Assets/_Code/_Editor/JobDescEditor.cs
@@ -257,7 +257,7 @@ namespace Aqua.Editor
             JobDesc job = (JobDesc) target;
             JobDesc.EditorJobTask jobTask = job.m_Tasks[index];
             EditorGUI.LabelField(rect, jobTask.Id.ToDebugString());
-        }
+        } 
 
         private void RenderTaskSettings(JobDesc inJob, int inIndex) {
             if (inIndex < 0 || inIndex >= inJob.m_Tasks.Length) {
@@ -270,9 +270,14 @@ namespace Aqua.Editor
                     SerializedProperty idProperty = taskAsProperty.FindPropertyRelative("Id");
                     SerializedProperty labelProperty = taskAsProperty.FindPropertyRelative("LabelId");
                     SerializedProperty categoryProperty = taskAsProperty.FindPropertyRelative("Category");
+                    SerializedProperty taskComplexity = taskAsProperty.FindPropertyRelative("TaskComplexity");
+                    SerializedProperty scaffoldingComplexity = taskAsProperty.FindPropertyRelative("ScaffoldingComplexity");
                     EditorGUILayout.PropertyField(idProperty);
                     EditorGUILayout.PropertyField(labelProperty);
                     EditorGUILayout.PropertyField(categoryProperty);
+                    EditorGUILayout.PropertyField(taskComplexity);
+                    EditorGUILayout.PropertyField(scaffoldingComplexity);
+
 
                     EditorGUILayout.Space();
 

--- a/Assets/_Code/_Editor/JobDescEditor.cs
+++ b/Assets/_Code/_Editor/JobDescEditor.cs
@@ -92,10 +92,10 @@ namespace Aqua.Editor
             m_CategoryProperty = serializedObject.FindProperty("m_Category");
             m_FlagsProperty = serializedObject.FindProperty("m_Flags");
             m_NameIdProperty = serializedObject.FindProperty("m_NameId");
-            m_TopicComplexityProperty = serializedObject.FindProperty("m_TopicComplexity");
             m_PosterIdProperty = serializedObject.FindProperty("m_PosterId");
             m_DescIdProperty = serializedObject.FindProperty("m_DescId");
             m_DescShortIdProperty = serializedObject.FindProperty("m_DescShortId");
+            m_TopicComplexityProperty = serializedObject.FindProperty("m_TopicComplexity");
             m_ExperimentDifficultyProperty = serializedObject.FindProperty("m_ExperimentDifficulty");
             m_ModelingDifficultyProperty = serializedObject.FindProperty("m_ModelingDifficulty");
             m_ArgumentationDifficultyProperty = serializedObject.FindProperty("m_ArgumentationDifficulty");
@@ -154,7 +154,6 @@ namespace Aqua.Editor
             EditorGUILayout.PropertyField(m_CategoryProperty);
             EditorGUILayout.PropertyField(m_FlagsProperty);
             EditorGUILayout.PropertyField(m_StationIdProperty);
-            EditorGUILayout.PropertyField(m_TopicComplexityProperty);
 
             if (Section("Text", ref m_TextExpanded)) {
                 EditorGUILayout.PropertyField(m_NameIdProperty);
@@ -242,6 +241,7 @@ namespace Aqua.Editor
                 EditorGUILayout.PropertyField(m_ExperimentDifficultyProperty);
                 EditorGUILayout.PropertyField(m_ModelingDifficultyProperty);
                 EditorGUILayout.PropertyField(m_ArgumentationDifficultyProperty);
+                EditorGUILayout.PropertyField(m_TopicComplexityProperty);
             }
 
             serializedObject.ApplyModifiedProperties();

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-above-n-below/above-n-below.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-above-n-below/above-n-below.asset
@@ -51,6 +51,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-above-n-below.task.scanNew
       m_HashValue: 2211061590
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -84,6 +86,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-above-n-below.task.countNew
       m_HashValue: 1901418690
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -119,6 +123,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-above-n-below.task.experimentInteractions
       m_HashValue: 1293197251
     Category: 3
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -130,29 +136,14 @@ MonoBehaviour:
     - m_Source: countNew
       m_HashValue: 1760192562
   - Id:
-      m_Source: createModel
-      m_HashValue: 2425868018
-    LabelId:
-      m_Source: jobs.arctic-above-n-below.task.createModel
-      m_HashValue: 3081049218
-    Category: 4
-    Steps:
-    - Type: 1
-      Target:
-        m_Source: Y_IceCrevice.Model.AboveAndBelowVisual
-        m_HashValue: 755100527
-      ConditionString: 
-      Amount: 0
-    PrerequisiteTaskIds:
-    - m_Source: experimentInteractions
-      m_HashValue: 2119170003
-  - Id:
       m_Source: reportBack
       m_HashValue: 2059105924
     LabelId:
       m_Source: jobs.arctic-above-n-below.task.reportBack
       m_HashValue: 2565893556
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 10
       Target:
@@ -163,6 +154,25 @@ MonoBehaviour:
     PrerequisiteTaskIds:
     - m_Source: createModel
       m_HashValue: 2425868018
+  - Id:
+      m_Source: createModel
+      m_HashValue: 2425868018
+    LabelId:
+      m_Source: jobs.arctic-above-n-below.task.createModel
+      m_HashValue: 3081049218
+    Category: 4
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
+    Steps:
+    - Type: 1
+      Target:
+        m_Source: Y_IceCrevice.Model.AboveAndBelowVisual
+        m_HashValue: 755100527
+      ConditionString: 
+      Amount: 0
+    PrerequisiteTaskIds:
+    - m_Source: experimentInteractions
+      m_HashValue: 2119170003
   m_OptimizedTaskList:
   - Id:
       m_Source: scanNew
@@ -172,6 +182,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-above-n-below.task.scanNew
       m_HashValue: 2211061590
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -206,6 +218,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-above-n-below.task.countNew
       m_HashValue: 1901418690
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -240,6 +254,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-above-n-below.task.experimentInteractions
       m_HashValue: 1293197251
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -256,6 +272,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-above-n-below.task.createModel
       m_HashValue: 3081049218
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -272,6 +290,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-above-n-below.task.reportBack
       m_HashValue: 2565893556
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-above-n-below/above-n-below.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-above-n-below/above-n-below.asset
@@ -182,8 +182,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-above-n-below.task.scanNew
       m_HashValue: 2211061590
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -218,8 +216,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-above-n-below.task.countNew
       m_HashValue: 1901418690
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -254,8 +250,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-above-n-below.task.experimentInteractions
       m_HashValue: 1293197251
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -272,8 +266,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-above-n-below.task.createModel
       m_HashValue: 3081049218
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -290,8 +282,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-above-n-below.task.reportBack
       m_HashValue: 2565893556
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-above-n-below/above-n-below.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-above-n-below/above-n-below.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: jobs.arctic-above-n-below.desc.short
     m_HashValue: 1565165233
+  m_TopicComplexity: 1
   m_ExperimentDifficulty: 2
   m_ModelingDifficulty: 1
   m_ArgumentationDifficulty: 1

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-cause-of-death/arctic-cause-of-death.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-cause-of-death/arctic-cause-of-death.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 3
   m_ExperimentDifficulty: 1
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 5

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-cause-of-death/arctic-cause-of-death.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-cause-of-death/arctic-cause-of-death.asset
@@ -157,8 +157,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-cause-of-death.task.environmentData
       m_HashValue: 1787861296
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -187,8 +185,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-cause-of-death.task.histPopData
       m_HashValue: 3348095174
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -211,8 +207,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-cause-of-death.task.currPopData
       m_HashValue: 2591358966
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -235,8 +229,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-cause-of-death.task.report
       m_HashValue: 3788287745
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-cause-of-death/arctic-cause-of-death.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-cause-of-death/arctic-cause-of-death.asset
@@ -57,6 +57,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-cause-of-death.task.environmentData
       m_HashValue: 1787861296
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -84,6 +86,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-cause-of-death.task.histPopData
       m_HashValue: 3348095174
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -105,6 +109,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-cause-of-death.task.currPopData
       m_HashValue: 2591358966
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -126,6 +132,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-cause-of-death.task.report
       m_HashValue: 3788287745
     Category: 5
+    TaskComplexity: 3
+    ScaffoldingComplexity: 3
     Steps:
     - Type: 10
       Target:
@@ -149,6 +157,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-cause-of-death.task.environmentData
       m_HashValue: 1787861296
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -177,6 +187,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-cause-of-death.task.histPopData
       m_HashValue: 3348095174
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -199,6 +211,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-cause-of-death.task.currPopData
       m_HashValue: 2591358966
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -221,6 +235,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-cause-of-death.task.report
       m_HashValue: 3788287745
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-disappearing-act/arctic-disappearing-act.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-disappearing-act/arctic-disappearing-act.asset
@@ -54,6 +54,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-disappearing-act.task.scanCritters
       m_HashValue: 3082152420
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -105,6 +107,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-disappearing-act.task.modelInteractions
       m_HashValue: 462683659
     Category: 4
+    TaskComplexity: 1
+    ScaffoldingComplexity: 3
     Steps:
     - Type: 1
       Target:
@@ -122,6 +126,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-disappearing-act.task.reportBack
       m_HashValue: 1337745444
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -141,6 +147,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-disappearing-act.task.scanCritters
       m_HashValue: 3082152420
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -193,6 +201,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-disappearing-act.task.modelInteractions
       m_HashValue: 462683659
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -209,6 +219,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-disappearing-act.task.reportBack
       m_HashValue: 1337745444
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-disappearing-act/arctic-disappearing-act.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-disappearing-act/arctic-disappearing-act.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 1
   m_ExperimentDifficulty: 2
   m_ModelingDifficulty: 2
   m_ArgumentationDifficulty: 1

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-disappearing-act/arctic-disappearing-act.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-disappearing-act/arctic-disappearing-act.asset
@@ -147,8 +147,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-disappearing-act.task.scanCritters
       m_HashValue: 3082152420
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -201,8 +199,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-disappearing-act.task.modelInteractions
       m_HashValue: 462683659
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -219,8 +215,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-disappearing-act.task.reportBack
       m_HashValue: 1337745444
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-endangered-seals/arctic-endangered-seals.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-endangered-seals/arctic-endangered-seals.asset
@@ -58,6 +58,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-endangered-seals.task.scanProb
       m_HashValue: 1456992639
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -73,6 +75,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-endangered-seals.task.modelSync
       m_HashValue: 922265941
     Category: 4
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -90,6 +94,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-endangered-seals.task.modelPredict
       m_HashValue: 3368937103
     Category: 4
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -107,6 +113,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-endangered-seals.task.reportBack
       m_HashValue: 3448420776
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -126,6 +134,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-endangered-seals.task.scanProb
       m_HashValue: 1456992639
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -142,6 +152,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-endangered-seals.task.modelSync
       m_HashValue: 922265941
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -158,6 +170,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-endangered-seals.task.modelPredict
       m_HashValue: 3368937103
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -174,6 +188,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-endangered-seals.task.reportBack
       m_HashValue: 3448420776
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-endangered-seals/arctic-endangered-seals.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-endangered-seals/arctic-endangered-seals.asset
@@ -134,8 +134,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-endangered-seals.task.scanProb
       m_HashValue: 1456992639
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -152,8 +150,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-endangered-seals.task.modelSync
       m_HashValue: 922265941
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -170,8 +166,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-endangered-seals.task.modelPredict
       m_HashValue: 3368937103
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -188,8 +182,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-endangered-seals.task.reportBack
       m_HashValue: 3448420776
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-endangered-seals/arctic-endangered-seals.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-endangered-seals/arctic-endangered-seals.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 5
   m_ModelingDifficulty: 4
   m_ArgumentationDifficulty: 4

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-in-ice/arctic-in-ice.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-in-ice/arctic-in-ice.asset
@@ -130,8 +130,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-in-ice.task.scanAlgae
       m_HashValue: 1480056617
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -148,8 +146,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-in-ice.task.countAlgae
       m_HashValue: 341190355
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -166,8 +162,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-in-ice.task.observeEat
       m_HashValue: 22104152
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -184,8 +178,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-in-ice.task.reportBack
       m_HashValue: 2304089719
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-in-ice/arctic-in-ice.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-in-ice/arctic-in-ice.asset
@@ -54,6 +54,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-in-ice.task.scanAlgae
       m_HashValue: 1480056617
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -69,6 +71,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-in-ice.task.countAlgae
       m_HashValue: 341190355
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -86,6 +90,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-in-ice.task.observeEat
       m_HashValue: 22104152
     Category: 3
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -103,6 +109,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-in-ice.task.reportBack
       m_HashValue: 2304089719
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 3
     Steps:
     - Type: 10
       Target:
@@ -122,6 +130,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-in-ice.task.scanAlgae
       m_HashValue: 1480056617
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -138,6 +148,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-in-ice.task.countAlgae
       m_HashValue: 341190355
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -154,6 +166,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-in-ice.task.observeEat
       m_HashValue: 22104152
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -170,6 +184,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-in-ice.task.reportBack
       m_HashValue: 2304089719
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-in-ice/arctic-in-ice.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-in-ice/arctic-in-ice.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 1
   m_ExperimentDifficulty: 1
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 2

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-isolated-instance/arctic-isolated-instance.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-isolated-instance/arctic-isolated-instance.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 3
   m_ExperimentDifficulty: 3
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 5

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-isolated-instance/arctic-isolated-instance.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-isolated-instance/arctic-isolated-instance.asset
@@ -55,6 +55,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-isolated-instance.task.scanAll
       m_HashValue: 899018090
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -112,6 +114,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-isolated-instance.task.checkCrab
       m_HashValue: 3396322836
     Category: 3
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 6
       Target:
@@ -129,82 +133,14 @@ MonoBehaviour:
     - m_Source: scanAll
       m_HashValue: 1784740587
   - Id:
-      m_Source: discussFindings
-      m_HashValue: 1442478067
-    LabelId:
-      m_Source: jobs.arctic-isolated-instance.task.discussFindings
-      m_HashValue: 1161848886
-    Category: 5
-    Steps:
-    - Type: 10
-      Target:
-        m_Source: argueIsolatedInstanceGroundwork
-        m_HashValue: 1631352399
-      ConditionString: 
-      Amount: 0
-    PrerequisiteTaskIds:
-    - m_Source: checkPredator
-      m_HashValue: 752639504
-    - m_Source: determineStress
-      m_HashValue: 2715794674
-  - Id:
-      m_Source: findPredator
-      m_HashValue: 427489029
-    LabelId:
-      m_Source: jobs.arctic-isolated-instance.task.findPredator
-      m_HashValue: 3034372890
-    Category: 2
-    Steps:
-    - Type: 0
-      Target:
-        m_Source: PterasterObscurus
-        m_HashValue: 1470134365
-      ConditionString: 
-      Amount: 0
-    PrerequisiteTaskIds:
-    - m_Source: discussFindings
-      m_HashValue: 1442478067
-  - Id:
-      m_Source: experimentPredatorAll
-      m_HashValue: 4140043772
-    LabelId:
-      m_Source: jobs.arctic-isolated-instance.task.experimentPredatorAll
-      m_HashValue: 3110267969
-    Category: 3
-    Steps:
-    - Type: 1
-      Target:
-        m_Source: PterasterObscurus.Eats.GlassSponge
-        m_HashValue: 497967974
-      ConditionString: 
-      Amount: 0
-    PrerequisiteTaskIds:
-    - m_Source: findPredator
-      m_HashValue: 427489029
-  - Id:
-      m_Source: countPopulations
-      m_HashValue: 1973731072
-    LabelId:
-      m_Source: jobs.arctic-isolated-instance.task.countPopulations
-      m_HashValue: 3286445159
-    Category: 2
-    Steps:
-    - Type: 1
-      Target:
-        m_Source: Y_IceCrevice.Population.PterasterObscurus
-        m_HashValue: 3870369418
-      ConditionString: 
-      Amount: 0
-    PrerequisiteTaskIds:
-    - m_Source: experimentPredatorAll
-      m_HashValue: 4140043772
-  - Id:
       m_Source: determineStress
       m_HashValue: 2715794674
     LabelId:
       m_Source: jobs.arctic-isolated-instance.task.determineStress
       m_HashValue: 4061817563
     Category: 3
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -226,12 +162,92 @@ MonoBehaviour:
       Amount: 0
     PrerequisiteTaskIds: []
   - Id:
+      m_Source: discussFindings
+      m_HashValue: 1442478067
+    LabelId:
+      m_Source: jobs.arctic-isolated-instance.task.discussFindings
+      m_HashValue: 1161848886
+    Category: 5
+    TaskComplexity: 3
+    ScaffoldingComplexity: 1
+    Steps:
+    - Type: 10
+      Target:
+        m_Source: argueIsolatedInstanceGroundwork
+        m_HashValue: 1631352399
+      ConditionString: 
+      Amount: 0
+    PrerequisiteTaskIds:
+    - m_Source: checkPredator
+      m_HashValue: 752639504
+    - m_Source: determineStress
+      m_HashValue: 2715794674
+  - Id:
+      m_Source: findPredator
+      m_HashValue: 427489029
+    LabelId:
+      m_Source: jobs.arctic-isolated-instance.task.findPredator
+      m_HashValue: 3034372890
+    Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
+    Steps:
+    - Type: 0
+      Target:
+        m_Source: PterasterObscurus
+        m_HashValue: 1470134365
+      ConditionString: 
+      Amount: 0
+    PrerequisiteTaskIds:
+    - m_Source: discussFindings
+      m_HashValue: 1442478067
+  - Id:
+      m_Source: experimentPredatorAll
+      m_HashValue: 4140043772
+    LabelId:
+      m_Source: jobs.arctic-isolated-instance.task.experimentPredatorAll
+      m_HashValue: 3110267969
+    Category: 3
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
+    Steps:
+    - Type: 1
+      Target:
+        m_Source: PterasterObscurus.Eats.GlassSponge
+        m_HashValue: 497967974
+      ConditionString: 
+      Amount: 0
+    PrerequisiteTaskIds:
+    - m_Source: findPredator
+      m_HashValue: 427489029
+  - Id:
+      m_Source: countPopulations
+      m_HashValue: 1973731072
+    LabelId:
+      m_Source: jobs.arctic-isolated-instance.task.countPopulations
+      m_HashValue: 3286445159
+    Category: 2
+    TaskComplexity: 1
+    ScaffoldingComplexity: 0
+    Steps:
+    - Type: 1
+      Target:
+        m_Source: Y_IceCrevice.Population.PterasterObscurus
+        m_HashValue: 3870369418
+      ConditionString: 
+      Amount: 0
+    PrerequisiteTaskIds:
+    - m_Source: experimentPredatorAll
+      m_HashValue: 4140043772
+  - Id:
       m_Source: reportFinal
       m_HashValue: 3284742193
     LabelId:
       m_Source: jobs.arctic-isolated-instance.task.reportFinal
       m_HashValue: 1351555032
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -253,6 +269,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-isolated-instance.task.scanAll
       m_HashValue: 899018090
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -311,6 +329,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-isolated-instance.task.checkCrab
       m_HashValue: 3396322836
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 6
       Target:
@@ -333,6 +353,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-isolated-instance.task.determineStress
       m_HashValue: 4061817563
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -361,6 +383,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-isolated-instance.task.discussFindings
       m_HashValue: 1161848886
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:
@@ -377,6 +401,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-isolated-instance.task.findPredator
       m_HashValue: 3034372890
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -393,6 +419,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-isolated-instance.task.experimentPredatorAll
       m_HashValue: 3110267969
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -409,6 +437,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-isolated-instance.task.countPopulations
       m_HashValue: 3286445159
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -425,6 +455,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-isolated-instance.task.reportFinal
       m_HashValue: 1351555032
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-isolated-instance/arctic-isolated-instance.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-isolated-instance/arctic-isolated-instance.asset
@@ -269,8 +269,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-isolated-instance.task.scanAll
       m_HashValue: 899018090
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -329,8 +327,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-isolated-instance.task.checkCrab
       m_HashValue: 3396322836
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 6
       Target:
@@ -353,8 +349,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-isolated-instance.task.determineStress
       m_HashValue: 4061817563
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -383,8 +377,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-isolated-instance.task.discussFindings
       m_HashValue: 1161848886
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:
@@ -401,8 +393,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-isolated-instance.task.findPredator
       m_HashValue: 3034372890
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -419,8 +409,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-isolated-instance.task.experimentPredatorAll
       m_HashValue: 3110267969
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -437,8 +425,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-isolated-instance.task.countPopulations
       m_HashValue: 3286445159
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -455,8 +441,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-isolated-instance.task.reportFinal
       m_HashValue: 1351555032
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-missing-whale/arctic-missing-whale.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-missing-whale/arctic-missing-whale.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 1
   m_ExperimentDifficulty: 0
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 2

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-missing-whale/arctic-missing-whale.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-missing-whale/arctic-missing-whale.asset
@@ -141,8 +141,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-missing-whale.task.findWhale
       m_HashValue: 3913478049
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -171,8 +169,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-missing-whale.task.findTracker
       m_HashValue: 2212038312
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -189,8 +185,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-missing-whale.task.foundDetritus
       m_HashValue: 441849813
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -207,8 +201,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-missing-whale.task.reportBack
       m_HashValue: 3992557886
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-missing-whale/arctic-missing-whale.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-missing-whale/arctic-missing-whale.asset
@@ -51,6 +51,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-missing-whale.task.findTracker
       m_HashValue: 2212038312
     Category: 2
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 0
       Target:
@@ -66,6 +68,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-missing-whale.task.findWhale
       m_HashValue: 3913478049
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -93,6 +97,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-missing-whale.task.foundDetritus
       m_HashValue: 441849813
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -110,6 +116,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-missing-whale.task.reportBack
       m_HashValue: 3992557886
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -133,6 +141,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-missing-whale.task.findWhale
       m_HashValue: 3913478049
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -161,6 +171,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-missing-whale.task.findTracker
       m_HashValue: 2212038312
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -177,6 +189,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-missing-whale.task.foundDetritus
       m_HashValue: 441849813
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -193,6 +207,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-missing-whale.task.reportBack
       m_HashValue: 3992557886
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-picky-eaters/arctic-picky-eaters.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-picky-eaters/arctic-picky-eaters.asset
@@ -110,8 +110,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-picky-eaters.task.obtainRateAlgae
       m_HashValue: 2898981155
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 2
       Target:
@@ -128,8 +126,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-picky-eaters.task.obtainRateDiatoms
       m_HashValue: 3850753496
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 2
       Target:
@@ -146,8 +142,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-picky-eaters.task.reportBack
       m_HashValue: 3696102411
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-picky-eaters/arctic-picky-eaters.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-picky-eaters/arctic-picky-eaters.asset
@@ -53,6 +53,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-picky-eaters.task.obtainRateAlgae
       m_HashValue: 2898981155
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 2
       Target:
@@ -68,6 +70,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-picky-eaters.task.obtainRateDiatoms
       m_HashValue: 3850753496
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 2
       Target:
@@ -83,6 +87,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-picky-eaters.task.reportBack
       m_HashValue: 3696102411
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 10
       Target:
@@ -104,6 +110,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-picky-eaters.task.obtainRateAlgae
       m_HashValue: 2898981155
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 2
       Target:
@@ -120,6 +128,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-picky-eaters.task.obtainRateDiatoms
       m_HashValue: 3850753496
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 2
       Target:
@@ -136,6 +146,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-picky-eaters.task.reportBack
       m_HashValue: 3696102411
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-picky-eaters/arctic-picky-eaters.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-picky-eaters/arctic-picky-eaters.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 3
   m_ExperimentDifficulty: 3
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 4

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-salmon-competition/arctic-salmon-competition.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-salmon-competition/arctic-salmon-competition.asset
@@ -55,6 +55,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-salmon-competition.task.observeCod
       m_HashValue: 2954528681
     Category: 3
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -76,6 +78,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-salmon-competition.task.modelFish
       m_HashValue: 1076608634
     Category: 4
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -93,6 +97,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-salmon-competition.task.reportBack
       m_HashValue: 2348588426
     Category: 5
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 10
       Target:
@@ -112,6 +118,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-salmon-competition.task.observeCod
       m_HashValue: 2954528681
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -134,6 +142,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-salmon-competition.task.modelFish
       m_HashValue: 1076608634
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -150,6 +160,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-salmon-competition.task.reportBack
       m_HashValue: 2348588426
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-salmon-competition/arctic-salmon-competition.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-salmon-competition/arctic-salmon-competition.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 1
   m_ModelingDifficulty: 3
   m_ArgumentationDifficulty: 4

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-salmon-competition/arctic-salmon-competition.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-salmon-competition/arctic-salmon-competition.asset
@@ -118,8 +118,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-salmon-competition.task.observeCod
       m_HashValue: 2954528681
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -142,8 +140,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-salmon-competition.task.modelFish
       m_HashValue: 1076608634
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -160,8 +156,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-salmon-competition.task.reportBack
       m_HashValue: 2348588426
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-salmon-monitoring/arctic-salmon-monitoring.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-salmon-monitoring/arctic-salmon-monitoring.asset
@@ -90,8 +90,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-salmon-monitoring.task.countSalmon
       m_HashValue: 3703017737
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -108,8 +106,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-salmon-monitoring.task.reportBack
       m_HashValue: 1229702077
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-salmon-monitoring/arctic-salmon-monitoring.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-salmon-monitoring/arctic-salmon-monitoring.asset
@@ -52,6 +52,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-salmon-monitoring.task.countSalmon
       m_HashValue: 3703017737
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -67,6 +69,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-salmon-monitoring.task.reportBack
       m_HashValue: 1229702077
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -86,6 +90,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-salmon-monitoring.task.countSalmon
       m_HashValue: 3703017737
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -102,6 +108,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-salmon-monitoring.task.reportBack
       m_HashValue: 1229702077
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-salmon-monitoring/arctic-salmon-monitoring.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-salmon-monitoring/arctic-salmon-monitoring.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 0
   m_ExperimentDifficulty: 0
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 1

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-seal-habitats/arctic-seal-habitats.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-seal-habitats/arctic-seal-habitats.asset
@@ -208,8 +208,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-seal-habbits.task.find2
       m_HashValue: 2291145815
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -226,8 +224,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-seal-habbits.task.find
       m_HashValue: 1053574303
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -244,8 +240,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-seal-habbits.task.find3
       m_HashValue: 2274368196
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -280,8 +274,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-seal-habbits.task.countSeal
       m_HashValue: 1198722562
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -298,8 +290,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-seal-habbits.task.countMicro
       m_HashValue: 1428529905
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -334,8 +324,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-seal-habbits.task.report
       m_HashValue: 598769310
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-seal-habitats/arctic-seal-habitats.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-seal-habitats/arctic-seal-habitats.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: jobs.arctic-seal-habbits.desc.short
     m_HashValue: 98025834
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 0
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 2

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-seal-habitats/arctic-seal-habitats.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-seal-habitats/arctic-seal-habitats.asset
@@ -52,6 +52,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-seal-habbits.task.find2
       m_HashValue: 2291145815
     Category: 1
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -67,6 +69,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-seal-habbits.task.find
       m_HashValue: 1053574303
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -82,6 +86,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-seal-habbits.task.countSeal
       m_HashValue: 1198722562
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -101,6 +107,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-seal-habbits.task.find3
       m_HashValue: 2274368196
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -138,6 +146,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-seal-habbits.task.countMicro
       m_HashValue: 1428529905
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -173,6 +183,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-seal-habbits.task.report
       m_HashValue: 598769310
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -196,6 +208,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-seal-habbits.task.find2
       m_HashValue: 2291145815
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -212,6 +226,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-seal-habbits.task.find
       m_HashValue: 1053574303
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -228,6 +244,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-seal-habbits.task.find3
       m_HashValue: 2274368196
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -262,6 +280,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-seal-habbits.task.countSeal
       m_HashValue: 1198722562
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -278,6 +298,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-seal-habbits.task.countMicro
       m_HashValue: 1428529905
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -312,6 +334,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-seal-habbits.task.report
       m_HashValue: 598769310
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-stationary-survival/arctic-stationary-survival.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-stationary-survival/arctic-stationary-survival.asset
@@ -92,8 +92,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-stationary-survival.task.visualModel
       m_HashValue: 2794333081
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -110,8 +108,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-stationary-survival.task.report
       m_HashValue: 1224077706
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-stationary-survival/arctic-stationary-survival.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-stationary-survival/arctic-stationary-survival.asset
@@ -54,6 +54,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-stationary-survival.task.visualModel
       m_HashValue: 2794333081
     Category: 4
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -69,6 +71,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-stationary-survival.task.report
       m_HashValue: 1224077706
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 10
       Target:
@@ -88,6 +92,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-stationary-survival.task.visualModel
       m_HashValue: 2794333081
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -104,6 +110,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-stationary-survival.task.report
       m_HashValue: 1224077706
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-stationary-survival/arctic-stationary-survival.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-stationary-survival/arctic-stationary-survival.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 1
   m_ModelingDifficulty: 2
   m_ArgumentationDifficulty: 1

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-time-of-death/arctic-time-of-death.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-time-of-death/arctic-time-of-death.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 0
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 5

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-time-of-death/arctic-time-of-death.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-time-of-death/arctic-time-of-death.asset
@@ -142,8 +142,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-time-of-death.task.popData
       m_HashValue: 2150234396
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -214,8 +212,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-time-of-death.task.report
       m_HashValue: 2036953559
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-time-of-death/arctic-time-of-death.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-time-of-death/arctic-time-of-death.asset
@@ -52,6 +52,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-time-of-death.task.popData
       m_HashValue: 2150234396
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -121,6 +123,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-time-of-death.task.report
       m_HashValue: 2036953559
     Category: 5
+    TaskComplexity: 3
+    ScaffoldingComplexity: 3
     Steps:
     - Type: 10
       Target:
@@ -138,6 +142,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-time-of-death.task.popData
       m_HashValue: 2150234396
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -208,6 +214,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-time-of-death.task.report
       m_HashValue: 2036953559
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-underneath/arctic-underneath.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-underneath/arctic-underneath.asset
@@ -100,8 +100,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-underneath.task.explore
       m_HashValue: 2393795236
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -130,8 +128,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-underneath.task.report
       m_HashValue: 2022947651
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-underneath/arctic-underneath.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-underneath/arctic-underneath.asset
@@ -50,6 +50,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-underneath.task.explore
       m_HashValue: 2393795236
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -77,6 +79,8 @@ MonoBehaviour:
       m_Source: jobs.arctic-underneath.task.report
       m_HashValue: 2022947651
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -96,6 +100,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-underneath.task.explore
       m_HashValue: 2393795236
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -124,6 +130,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.arctic-underneath.task.report
       m_HashValue: 2022947651
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/ArcticStationJobs/arctic-underneath/arctic-underneath.asset
+++ b/Assets/_Content/Jobs/ArcticStationJobs/arctic-underneath/arctic-underneath.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 1
   m_ExperimentDifficulty: 0
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 1

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-alt-energy/bayou-alt-energy.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-alt-energy/bayou-alt-energy.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 3
   m_ExperimentDifficulty: 1
   m_ModelingDifficulty: 1
   m_ArgumentationDifficulty: 3

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-alt-energy/bayou-alt-energy.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-alt-energy/bayou-alt-energy.asset
@@ -178,8 +178,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-alt-energy.task.scanCritters
       m_HashValue: 3719801694
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -214,8 +212,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-alt-energy.task.wormEat
       m_HashValue: 1374080358
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -262,8 +258,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-alt-energy.task.getModel
       m_HashValue: 26718178
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -280,8 +274,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-alt-energy.task.reportBack
       m_HashValue: 2565562506
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-alt-energy/bayou-alt-energy.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-alt-energy/bayou-alt-energy.asset
@@ -54,6 +54,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-alt-energy.task.scanCritters
       m_HashValue: 3719801694
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -87,6 +89,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-alt-energy.task.getModel
       m_HashValue: 26718178
     Category: 4
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -104,6 +108,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-alt-energy.task.wormEat
       m_HashValue: 1374080358
     Category: 3
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -151,6 +157,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-alt-energy.task.reportBack
       m_HashValue: 2565562506
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -170,6 +178,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-alt-energy.task.scanCritters
       m_HashValue: 3719801694
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -204,6 +214,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-alt-energy.task.wormEat
       m_HashValue: 1374080358
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -250,6 +262,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-alt-energy.task.getModel
       m_HashValue: 26718178
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -266,6 +280,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-alt-energy.task.reportBack
       m_HashValue: 2565562506
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-blue-waters/bayou-blue-waters.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-blue-waters/bayou-blue-waters.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 5
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 1

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-blue-waters/bayou-blue-waters.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-blue-waters/bayou-blue-waters.asset
@@ -56,6 +56,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-blue-waters.task.findGreen
       m_HashValue: 1409134536
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -71,6 +73,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-blue-waters.task.countGreen
       m_HashValue: 3601678308
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -88,6 +92,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-blue-waters.task.stressCyano
       m_HashValue: 1650652442
     Category: 3
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -117,6 +123,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-blue-waters.task.measureEffect
       m_HashValue: 48409999
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -140,6 +148,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-blue-waters.task.measureReproduce
       m_HashValue: 163555937
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -163,6 +173,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-blue-waters.task.reportBack
       m_HashValue: 293906583
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -184,6 +196,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-blue-waters.task.findGreen
       m_HashValue: 1409134536
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -200,6 +214,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-blue-waters.task.countGreen
       m_HashValue: 3601678308
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -216,6 +232,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-blue-waters.task.stressCyano
       m_HashValue: 1650652442
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -244,6 +262,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-blue-waters.task.measureEffect
       m_HashValue: 48409999
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -266,6 +286,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-blue-waters.task.measureReproduce
       m_HashValue: 163555937
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -288,6 +310,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-blue-waters.task.reportBack
       m_HashValue: 293906583
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-blue-waters/bayou-blue-waters.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-blue-waters/bayou-blue-waters.asset
@@ -196,8 +196,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-blue-waters.task.findGreen
       m_HashValue: 1409134536
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -214,8 +212,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-blue-waters.task.countGreen
       m_HashValue: 3601678308
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -232,8 +228,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-blue-waters.task.stressCyano
       m_HashValue: 1650652442
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -262,8 +256,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-blue-waters.task.measureEffect
       m_HashValue: 48409999
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -286,8 +278,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-blue-waters.task.measureReproduce
       m_HashValue: 163555937
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -310,8 +300,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-blue-waters.task.reportBack
       m_HashValue: 293906583
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-boom-cause/bayou-boom-cause.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-boom-cause/bayou-boom-cause.asset
@@ -52,6 +52,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-boom-cause.task.methaneScan
       m_HashValue: 1946488341
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -67,6 +69,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-boom-cause.task.methaneTag
       m_HashValue: 2353647372
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -84,6 +88,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-boom-cause.task.reportBack
       m_HashValue: 1068100685
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -103,6 +109,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-boom-cause.task.methaneScan
       m_HashValue: 1946488341
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -119,6 +127,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-boom-cause.task.methaneTag
       m_HashValue: 2353647372
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -135,6 +145,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-boom-cause.task.reportBack
       m_HashValue: 1068100685
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-boom-cause/bayou-boom-cause.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-boom-cause/bayou-boom-cause.asset
@@ -109,8 +109,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-boom-cause.task.methaneScan
       m_HashValue: 1946488341
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -127,8 +125,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-boom-cause.task.methaneTag
       m_HashValue: 2353647372
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -145,8 +141,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-boom-cause.task.reportBack
       m_HashValue: 1068100685
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-boom-cause/bayou-boom-cause.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-boom-cause/bayou-boom-cause.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 0
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 3

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-dirty-detritus/bayou-dirty-detritus.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-dirty-detritus/bayou-dirty-detritus.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 3
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 3

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-dirty-detritus/bayou-dirty-detritus.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-dirty-detritus/bayou-dirty-detritus.asset
@@ -193,8 +193,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-dirty-detritus.task.scanNew
       m_HashValue: 2649751307
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -229,8 +227,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-dirty-detritus.task.scanProbe
       m_HashValue: 2501360479
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -247,8 +243,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-dirty-detritus.task.countDetritus
       m_HashValue: 823452073
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -265,8 +259,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-dirty-detritus.task.eatDetritus
       m_HashValue: 3826345904
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -283,8 +275,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-dirty-detritus.task.growDetritus
       m_HashValue: 3391774869
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 6
       Target:
@@ -301,8 +291,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-dirty-detritus.task.reportBack
       m_HashValue: 2766880759
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-dirty-detritus/bayou-dirty-detritus.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-dirty-detritus/bayou-dirty-detritus.asset
@@ -53,6 +53,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-dirty-detritus.task.scanNew
       m_HashValue: 2649751307
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -86,6 +88,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-dirty-detritus.task.scanProbe
       m_HashValue: 2501360479
     Category: 5
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -103,6 +107,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-dirty-detritus.task.countDetritus
       m_HashValue: 823452073
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -118,6 +124,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-dirty-detritus.task.eatDetritus
       m_HashValue: 3826345904
     Category: 3
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -139,6 +147,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-dirty-detritus.task.growDetritus
       m_HashValue: 3391774869
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 6
       Target:
@@ -160,6 +170,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-dirty-detritus.task.reportBack
       m_HashValue: 2766880759
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -181,6 +193,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-dirty-detritus.task.scanNew
       m_HashValue: 2649751307
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -215,6 +229,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-dirty-detritus.task.scanProbe
       m_HashValue: 2501360479
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -231,6 +247,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-dirty-detritus.task.countDetritus
       m_HashValue: 823452073
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -247,6 +265,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-dirty-detritus.task.eatDetritus
       m_HashValue: 3826345904
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -263,6 +283,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-dirty-detritus.task.growDetritus
       m_HashValue: 3391774869
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 6
       Target:
@@ -279,6 +301,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-dirty-detritus.task.reportBack
       m_HashValue: 2766880759
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-displaced-reef/displaced-reef.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-displaced-reef/displaced-reef.asset
@@ -50,6 +50,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-displaced-reef.task.visitSiteO
       m_HashValue: 1545989578
     Category: 1
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 3
       Target:
@@ -65,6 +67,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-displaced-reef.task.getScans
       m_HashValue: 997294805
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -106,6 +110,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-displaced-reef.task.getCounts
       m_HashValue: 774222265
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -147,6 +153,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-displaced-reef.task.reportBack
       m_HashValue: 1790074046
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 10
       Target:
@@ -166,6 +174,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-displaced-reef.task.visitSiteO
       m_HashValue: 1545989578
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 3
       Target:
@@ -182,6 +192,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-displaced-reef.task.getScans
       m_HashValue: 997294805
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -222,6 +234,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-displaced-reef.task.getCounts
       m_HashValue: 774222265
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -262,6 +276,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-displaced-reef.task.reportBack
       m_HashValue: 1790074046
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-displaced-reef/displaced-reef.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-displaced-reef/displaced-reef.asset
@@ -174,8 +174,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-displaced-reef.task.visitSiteO
       m_HashValue: 1545989578
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 3
       Target:
@@ -192,8 +190,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-displaced-reef.task.getScans
       m_HashValue: 997294805
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -234,8 +230,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-displaced-reef.task.getCounts
       m_HashValue: 774222265
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -276,8 +270,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-displaced-reef.task.reportBack
       m_HashValue: 1790074046
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-displaced-reef/displaced-reef.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-displaced-reef/displaced-reef.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 1
   m_ExperimentDifficulty: 0
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 2

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-hide-n-seek/bayou-hide-n-seek.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-hide-n-seek/bayou-hide-n-seek.asset
@@ -54,6 +54,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-hide-n-seek.task.jellyScan
       m_HashValue: 1634092768
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -69,6 +71,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-hide-n-seek.task.jellyObservation
       m_HashValue: 305936581
     Category: 3
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -86,6 +90,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-hide-n-seek.task.jellyRates
       m_HashValue: 3222764180
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 2
       Target:
@@ -103,6 +109,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-hide-n-seek.task.jellyPredict
       m_HashValue: 3442040818
     Category: 4
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -122,6 +130,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-hide-n-seek.task.reportBack
       m_HashValue: 3249270262
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -141,6 +151,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-hide-n-seek.task.jellyScan
       m_HashValue: 1634092768
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -157,6 +169,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-hide-n-seek.task.jellyObservation
       m_HashValue: 305936581
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -173,6 +187,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-hide-n-seek.task.jellyRates
       m_HashValue: 3222764180
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 2
       Target:
@@ -189,6 +205,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-hide-n-seek.task.jellyPredict
       m_HashValue: 3442040818
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -205,6 +223,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-hide-n-seek.task.reportBack
       m_HashValue: 3249270262
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-hide-n-seek/bayou-hide-n-seek.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-hide-n-seek/bayou-hide-n-seek.asset
@@ -151,8 +151,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-hide-n-seek.task.jellyScan
       m_HashValue: 1634092768
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -169,8 +167,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-hide-n-seek.task.jellyObservation
       m_HashValue: 305936581
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -187,8 +183,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-hide-n-seek.task.jellyRates
       m_HashValue: 3222764180
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 2
       Target:
@@ -205,8 +199,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-hide-n-seek.task.jellyPredict
       m_HashValue: 3442040818
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -223,8 +215,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-hide-n-seek.task.reportBack
       m_HashValue: 3249270262
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-hide-n-seek/bayou-hide-n-seek.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-hide-n-seek/bayou-hide-n-seek.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 3
   m_ModelingDifficulty: 4
   m_ArgumentationDifficulty: 3

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-methanogen/bayou-methanogen.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-methanogen/bayou-methanogen.asset
@@ -54,6 +54,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-methanogen.task.eatRules
       m_HashValue: 1258523636
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -75,6 +77,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-methanogen.task.stressRanges
       m_HashValue: 3306379975
     Category: 3
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -102,6 +106,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-methanogen.task.waterChem
       m_HashValue: 333240985
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -123,6 +129,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-methanogen.task.report
       m_HashValue: 1529160575
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 10
       Target:
@@ -146,6 +154,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-methanogen.task.eatRules
       m_HashValue: 1258523636
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -168,6 +178,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-methanogen.task.stressRanges
       m_HashValue: 3306379975
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -196,6 +208,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-methanogen.task.waterChem
       m_HashValue: 333240985
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -218,6 +232,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-methanogen.task.report
       m_HashValue: 1529160575
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-methanogen/bayou-methanogen.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-methanogen/bayou-methanogen.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: jobs.bayou-methanogen.desc.short
     m_HashValue: 1157150941
+  m_TopicComplexity: 3
   m_ExperimentDifficulty: 4
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 3

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-methanogen/bayou-methanogen.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-methanogen/bayou-methanogen.asset
@@ -154,8 +154,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-methanogen.task.eatRules
       m_HashValue: 1258523636
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -178,8 +176,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-methanogen.task.stressRanges
       m_HashValue: 3306379975
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -208,8 +204,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-methanogen.task.waterChem
       m_HashValue: 333240985
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -232,8 +226,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-methanogen.task.report
       m_HashValue: 1529160575
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-oxygen-tracking/bayou-oxygen-tracking.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-oxygen-tracking/bayou-oxygen-tracking.asset
@@ -166,8 +166,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-oxygen-tracking.task.scanAll
       m_HashValue: 2985964401
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -202,8 +200,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-oxygen-tracking.task.measureCritters
       m_HashValue: 4121309477
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -232,8 +228,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-oxygen-tracking.task.makeVisual
       m_HashValue: 3040521573
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -250,8 +244,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-oxygen-tracking.task.reportBack
       m_HashValue: 563622658
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-oxygen-tracking/bayou-oxygen-tracking.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-oxygen-tracking/bayou-oxygen-tracking.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 3
   m_ExperimentDifficulty: 3
   m_ModelingDifficulty: 3
   m_ArgumentationDifficulty: 4

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-oxygen-tracking/bayou-oxygen-tracking.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-oxygen-tracking/bayou-oxygen-tracking.asset
@@ -60,6 +60,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-oxygen-tracking.task.scanAll
       m_HashValue: 2985964401
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -93,6 +95,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-oxygen-tracking.task.measureCritters
       m_HashValue: 4121309477
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -122,6 +126,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-oxygen-tracking.task.makeVisual
       m_HashValue: 3040521573
     Category: 4
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -139,6 +145,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-oxygen-tracking.task.reportBack
       m_HashValue: 563622658
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -158,6 +166,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-oxygen-tracking.task.scanAll
       m_HashValue: 2985964401
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -192,6 +202,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-oxygen-tracking.task.measureCritters
       m_HashValue: 4121309477
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -220,6 +232,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-oxygen-tracking.task.makeVisual
       m_HashValue: 3040521573
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -236,6 +250,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-oxygen-tracking.task.reportBack
       m_HashValue: 563622658
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-reef-decision/bayou-reef-decision.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-reef-decision/bayou-reef-decision.asset
@@ -53,6 +53,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-reef-decision.task.intervene
       m_HashValue: 4273402540
     Category: 4
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -68,6 +70,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-reef-decision.task.reportBack
       m_HashValue: 594596747
     Category: 5
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 10
       Target:
@@ -87,6 +91,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-reef-decision.task.intervene
       m_HashValue: 4273402540
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -103,6 +109,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-reef-decision.task.reportBack
       m_HashValue: 594596747
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-reef-decision/bayou-reef-decision.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-reef-decision/bayou-reef-decision.asset
@@ -91,8 +91,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-reef-decision.task.intervene
       m_HashValue: 4273402540
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -109,8 +107,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-reef-decision.task.reportBack
       m_HashValue: 594596747
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-reef-decision/bayou-reef-decision.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-reef-decision/bayou-reef-decision.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 3
   m_ExperimentDifficulty: 0
   m_ModelingDifficulty: 4
   m_ArgumentationDifficulty: 1

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-shrimp-tastrophe/bayou-shrimp-tastrophe.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-shrimp-tastrophe/bayou-shrimp-tastrophe.asset
@@ -59,6 +59,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-shrimp-tastrophe.task.createModel
       m_HashValue: 1297064466
     Category: 4
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -74,6 +76,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-shrimp-tastrophe.task.reportBack
       m_HashValue: 2059161252
     Category: 5
+    TaskComplexity: 3
+    ScaffoldingComplexity: 3
     Steps:
     - Type: 10
       Target:
@@ -93,6 +97,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-shrimp-tastrophe.task.createModel
       m_HashValue: 1297064466
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -109,6 +115,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-shrimp-tastrophe.task.reportBack
       m_HashValue: 2059161252
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-shrimp-tastrophe/bayou-shrimp-tastrophe.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-shrimp-tastrophe/bayou-shrimp-tastrophe.asset
@@ -97,8 +97,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-shrimp-tastrophe.task.createModel
       m_HashValue: 1297064466
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -115,8 +113,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-shrimp-tastrophe.task.reportBack
       m_HashValue: 2059161252
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-shrimp-tastrophe/bayou-shrimp-tastrophe.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-shrimp-tastrophe/bayou-shrimp-tastrophe.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 3
   m_ExperimentDifficulty: 5
   m_ModelingDifficulty: 5
   m_ArgumentationDifficulty: 5

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-shrimp-yields/bayou-shrimp-yields.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-shrimp-yields/bayou-shrimp-yields.asset
@@ -96,8 +96,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-shrimp-yields.task.countShrimp
       m_HashValue: 3287213555
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -120,8 +118,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-shrimp-yields.task.reportBack
       m_HashValue: 2543870728
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-shrimp-yields/bayou-shrimp-yields.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-shrimp-yields/bayou-shrimp-yields.asset
@@ -46,29 +46,14 @@ MonoBehaviour:
   - m_HashValue: 3168968926
   m_Tasks:
   - Id:
-      m_Source: reportBack
-      m_HashValue: 2059105924
-    LabelId:
-      m_Source: jobs.bayou-shrimp-yields.task.reportBack
-      m_HashValue: 2543870728
-    Category: 5
-    Steps:
-    - Type: 10
-      Target:
-        m_Source: 
-        m_HashValue: 0
-      ConditionString: 
-      Amount: 0
-    PrerequisiteTaskIds:
-    - m_Source: countShrimp
-      m_HashValue: 3862329527
-  - Id:
       m_Source: countShrimp
       m_HashValue: 3862329527
     LabelId:
       m_Source: jobs.bayou-shrimp-yields.task.countShrimp
       m_HashValue: 3287213555
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -83,6 +68,25 @@ MonoBehaviour:
       ConditionString: 
       Amount: 0
     PrerequisiteTaskIds: []
+  - Id:
+      m_Source: reportBack
+      m_HashValue: 2059105924
+    LabelId:
+      m_Source: jobs.bayou-shrimp-yields.task.reportBack
+      m_HashValue: 2543870728
+    Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
+    Steps:
+    - Type: 10
+      Target:
+        m_Source: 
+        m_HashValue: 0
+      ConditionString: 
+      Amount: 0
+    PrerequisiteTaskIds:
+    - m_Source: countShrimp
+      m_HashValue: 3862329527
   m_OptimizedTaskList:
   - Id:
       m_Source: countShrimp
@@ -92,6 +96,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-shrimp-yields.task.countShrimp
       m_HashValue: 3287213555
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -114,6 +120,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-shrimp-yields.task.reportBack
       m_HashValue: 2543870728
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-shrimp-yields/bayou-shrimp-yields.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-shrimp-yields/bayou-shrimp-yields.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 0
   m_ExperimentDifficulty: 0
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 3

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-turtle-danger/turtle-danger.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-turtle-danger/turtle-danger.asset
@@ -153,8 +153,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-turtle-danger.task.scanCyano
       m_HashValue: 2164627182
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -171,8 +169,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-turtle-danger.task.countCyano
       m_HashValue: 2371982670
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -189,8 +185,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-turtle-danger.task.modelSiteO
       m_HashValue: 2817148168
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -213,8 +207,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-turtle-danger.task.visualModelO
       m_HashValue: 529884717
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -231,8 +223,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-turtle-danger.task.reportBack
       m_HashValue: 586683870
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-turtle-danger/turtle-danger.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-turtle-danger/turtle-danger.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 1
   m_ModelingDifficulty: 1
   m_ArgumentationDifficulty: 4

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-turtle-danger/turtle-danger.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-turtle-danger/turtle-danger.asset
@@ -52,6 +52,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-turtle-danger.task.scanCyano
       m_HashValue: 2164627182
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -67,6 +69,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-turtle-danger.task.countCyano
       m_HashValue: 2371982670
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -84,6 +88,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-turtle-danger.task.modelSiteO
       m_HashValue: 2817148168
     Category: 3
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -107,6 +113,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-turtle-danger.task.visualModelO
       m_HashValue: 529884717
     Category: 4
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -124,6 +132,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-turtle-danger.task.reportBack
       m_HashValue: 586683870
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -143,6 +153,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-turtle-danger.task.scanCyano
       m_HashValue: 2164627182
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -159,6 +171,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-turtle-danger.task.countCyano
       m_HashValue: 2371982670
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -175,6 +189,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-turtle-danger.task.modelSiteO
       m_HashValue: 2817148168
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -197,6 +213,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-turtle-danger.task.visualModelO
       m_HashValue: 529884717
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -213,6 +231,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-turtle-danger.task.reportBack
       m_HashValue: 586683870
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-turtle-danger2/turtle-danger2.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-turtle-danger2/turtle-danger2.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 3
   m_ExperimentDifficulty: 4
   m_ModelingDifficulty: 3
   m_ArgumentationDifficulty: 1

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-turtle-danger2/turtle-danger2.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-turtle-danger2/turtle-danger2.asset
@@ -58,6 +58,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-turtle-danger2.task.historicalData
       m_HashValue: 561240601
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -73,6 +75,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-turtle-danger2.task.measureStress
       m_HashValue: 385744503
     Category: 3
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -120,6 +124,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-turtle-danger2.task.syncModel
       m_HashValue: 934407639
     Category: 4
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -137,6 +143,8 @@ MonoBehaviour:
       m_Source: jobs.bayou-turtle-danger2.task.reportBack
       m_HashValue: 3896749188
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -156,6 +164,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-turtle-danger2.task.historicalData
       m_HashValue: 561240601
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -172,6 +182,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-turtle-danger2.task.measureStress
       m_HashValue: 385744503
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -218,6 +230,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-turtle-danger2.task.syncModel
       m_HashValue: 934407639
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -234,6 +248,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-turtle-danger2.task.reportBack
       m_HashValue: 3896749188
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/BayouStationJobs/bayou-turtle-danger2/turtle-danger2.asset
+++ b/Assets/_Content/Jobs/BayouStationJobs/bayou-turtle-danger2/turtle-danger2.asset
@@ -164,8 +164,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-turtle-danger2.task.historicalData
       m_HashValue: 561240601
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -182,8 +180,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-turtle-danger2.task.measureStress
       m_HashValue: 385744503
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -230,8 +226,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-turtle-danger2.task.syncModel
       m_HashValue: 934407639
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -248,8 +242,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.bayou-turtle-danger2.task.reportBack
       m_HashValue: 3896749188
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-casting-shade/coral-casting-shade.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-casting-shade/coral-casting-shade.asset
@@ -272,8 +272,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.scanSarg
       m_HashValue: 2433147327
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -290,8 +288,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.popProbe
       m_HashValue: 1355691134
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -308,8 +304,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.chemHistory
       m_HashValue: 176418440
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -332,8 +326,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.sargGrowthRate
       m_HashValue: 2731220687
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 2
       Target:
@@ -350,8 +342,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.sargLight
       m_HashValue: 1947787242
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -368,8 +358,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.coralGrowthRate
       m_HashValue: 1335604207
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -386,8 +374,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.coralGrowthStressed
       m_HashValue: 1512437364
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -404,8 +390,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.coralLight
       m_HashValue: 3729462090
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -422,8 +406,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.sargModel
       m_HashValue: 1811849747
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -440,8 +422,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.sargArgue
       m_HashValue: 68390100
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-casting-shade/coral-casting-shade.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-casting-shade/coral-casting-shade.asset
@@ -58,6 +58,8 @@ MonoBehaviour:
       m_Source: jobs.coral-casting-shade.task.scanSarg
       m_HashValue: 2433147327
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -73,6 +75,8 @@ MonoBehaviour:
       m_Source: jobs.coral-casting-shade.task.popProbe
       m_HashValue: 1355691134
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -90,6 +94,8 @@ MonoBehaviour:
       m_Source: jobs.coral-casting-shade.task.chemHistory
       m_HashValue: 176418440
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -113,6 +119,8 @@ MonoBehaviour:
       m_Source: jobs.coral-casting-shade.task.sargGrowthRate
       m_HashValue: 2731220687
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 2
       Target:
@@ -132,6 +140,8 @@ MonoBehaviour:
       m_Source: jobs.coral-casting-shade.task.sargLight
       m_HashValue: 1947787242
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -151,6 +161,8 @@ MonoBehaviour:
       m_Source: jobs.coral-casting-shade.task.coralGrowthRate
       m_HashValue: 1335604207
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -170,6 +182,8 @@ MonoBehaviour:
       m_Source: jobs.coral-casting-shade.task.coralGrowthStressed
       m_HashValue: 1512437364
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -189,6 +203,8 @@ MonoBehaviour:
       m_Source: jobs.coral-casting-shade.task.coralLight
       m_HashValue: 3729462090
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -208,6 +224,8 @@ MonoBehaviour:
       m_Source: jobs.coral-casting-shade.task.sargModel
       m_HashValue: 1811849747
     Category: 4
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 1
       Target:
@@ -233,6 +251,8 @@ MonoBehaviour:
       m_Source: jobs.coral-casting-shade.task.sargArgue
       m_HashValue: 68390100
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -252,6 +272,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.scanSarg
       m_HashValue: 2433147327
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -268,6 +290,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.popProbe
       m_HashValue: 1355691134
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -284,6 +308,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.chemHistory
       m_HashValue: 176418440
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -306,6 +332,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.sargGrowthRate
       m_HashValue: 2731220687
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 2
       Target:
@@ -322,6 +350,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.sargLight
       m_HashValue: 1947787242
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -338,6 +368,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.coralGrowthRate
       m_HashValue: 1335604207
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -354,6 +386,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.coralGrowthStressed
       m_HashValue: 1512437364
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -370,6 +404,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.coralLight
       m_HashValue: 3729462090
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -386,6 +422,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.sargModel
       m_HashValue: 1811849747
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -402,6 +440,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-casting-shade.task.sargArgue
       m_HashValue: 68390100
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-casting-shade/coral-casting-shade.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-casting-shade/coral-casting-shade.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 3
   m_ModelingDifficulty: 3
   m_ArgumentationDifficulty: 1

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-eat-seaweed/coral-eat-seaweed.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-eat-seaweed/coral-eat-seaweed.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 0
   m_ExperimentDifficulty: 2
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 2

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-eat-seaweed/coral-eat-seaweed.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-eat-seaweed/coral-eat-seaweed.asset
@@ -51,6 +51,8 @@ MonoBehaviour:
       m_Source: jobs.eat-seaweed.task.urchinSarg
       m_HashValue: 1941742485
     Category: 3
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 1
       Target:
@@ -66,6 +68,8 @@ MonoBehaviour:
       m_Source: jobs.eat-seaweed.task.urchinSargArgue
       m_HashValue: 1390670041
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -85,6 +89,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.eat-seaweed.task.urchinSarg
       m_HashValue: 1941742485
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -101,6 +107,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.eat-seaweed.task.urchinSargArgue
       m_HashValue: 1390670041
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-eat-seaweed/coral-eat-seaweed.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-eat-seaweed/coral-eat-seaweed.asset
@@ -89,8 +89,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.eat-seaweed.task.urchinSarg
       m_HashValue: 1941742485
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -107,8 +105,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.eat-seaweed.task.urchinSargArgue
       m_HashValue: 1390670041
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-fake-fix/coral-fake-fix.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-fake-fix/coral-fake-fix.asset
@@ -54,6 +54,8 @@ MonoBehaviour:
       m_Source: jobs.coral-fake-fix.task.findReef
       m_HashValue: 582871392
     Category: 1
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 6
       Target:
@@ -69,6 +71,8 @@ MonoBehaviour:
       m_Source: jobs.coral-fake-fix.task.scanProbes
       m_HashValue: 2187502867
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -90,6 +94,8 @@ MonoBehaviour:
       m_Source: jobs.coral-fake-fix.task.countPopulation
       m_HashValue: 171382323
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -111,6 +117,8 @@ MonoBehaviour:
       m_Source: jobs.coral-fake-fix.task.argue
       m_HashValue: 2670656969
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 10
       Target:
@@ -134,6 +142,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-fake-fix.task.findReef
       m_HashValue: 582871392
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 6
       Target:
@@ -150,6 +160,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-fake-fix.task.scanProbes
       m_HashValue: 2187502867
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -172,6 +184,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-fake-fix.task.countPopulation
       m_HashValue: 171382323
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -194,6 +208,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-fake-fix.task.argue
       m_HashValue: 2670656969
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-fake-fix/coral-fake-fix.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-fake-fix/coral-fake-fix.asset
@@ -142,8 +142,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-fake-fix.task.findReef
       m_HashValue: 582871392
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 6
       Target:
@@ -160,8 +158,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-fake-fix.task.scanProbes
       m_HashValue: 2187502867
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -184,8 +180,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-fake-fix.task.countPopulation
       m_HashValue: 171382323
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -208,8 +202,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-fake-fix.task.argue
       m_HashValue: 2670656969
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-fake-fix/coral-fake-fix.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-fake-fix/coral-fake-fix.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 0
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 4

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-fishy-bizz/coral-fishy-bizz.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-fishy-bizz/coral-fishy-bizz.asset
@@ -154,8 +154,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-fishy-bizz.task.getScans
       m_HashValue: 3516419945
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -190,8 +188,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-fishy-bizz.task.rhistoricalPopulations
       m_HashValue: 57648497
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -214,8 +210,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-fishy-bizz.task.getModel
       m_HashValue: 1352391234
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -232,8 +226,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-fishy-bizz.task.reportBack
       m_HashValue: 818144618
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-fishy-bizz/coral-fishy-bizz.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-fishy-bizz/coral-fishy-bizz.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 0
   m_ModelingDifficulty: 4
   m_ArgumentationDifficulty: 3

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-fishy-bizz/coral-fishy-bizz.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-fishy-bizz/coral-fishy-bizz.asset
@@ -54,6 +54,8 @@ MonoBehaviour:
       m_Source: jobs.coral-fishy-bizz.task.getScans
       m_HashValue: 3516419945
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -87,6 +89,8 @@ MonoBehaviour:
       m_Source: jobs.coral-fishy-bizz.task.rhistoricalPopulations
       m_HashValue: 57648497
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -108,6 +112,8 @@ MonoBehaviour:
       m_Source: jobs.coral-fishy-bizz.task.getModel
       m_HashValue: 1352391234
     Category: 4
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -127,6 +133,8 @@ MonoBehaviour:
       m_Source: jobs.coral-fishy-bizz.task.reportBack
       m_HashValue: 818144618
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -146,6 +154,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-fishy-bizz.task.getScans
       m_HashValue: 3516419945
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -180,6 +190,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-fishy-bizz.task.rhistoricalPopulations
       m_HashValue: 57648497
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -202,6 +214,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-fishy-bizz.task.getModel
       m_HashValue: 1352391234
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -218,6 +232,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-fishy-bizz.task.reportBack
       m_HashValue: 818144618
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-hunting-lions/coral-hunting-lions.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-hunting-lions/coral-hunting-lions.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 5
   m_ModelingDifficulty: 5
   m_ArgumentationDifficulty: 5

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-hunting-lions/coral-hunting-lions.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-hunting-lions/coral-hunting-lions.asset
@@ -59,6 +59,8 @@ MonoBehaviour:
       m_Source: jobs.coral-hunting-lions.task.scanCritters
       m_HashValue: 1635544448
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -122,6 +124,8 @@ MonoBehaviour:
       m_Source: jobs.coral-hunting-lions.task.scanHistory
       m_HashValue: 32716956
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -143,6 +147,8 @@ MonoBehaviour:
       m_Source: jobs.coral-hunting-lions.task.countPopulation
       m_HashValue: 3885012231
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -188,6 +194,8 @@ MonoBehaviour:
       m_Source: jobs.coral-hunting-lions.task.observeEatRules
       m_HashValue: 826814686
     Category: 3
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -223,6 +231,8 @@ MonoBehaviour:
       m_Source: jobs.coral-hunting-lions.task.measureEatRates
       m_HashValue: 1847961002
     Category: 3
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 2
       Target:
@@ -252,65 +262,14 @@ MonoBehaviour:
     - m_Source: obtainStressRules
       m_HashValue: 3804672883
   - Id:
-      m_Source: measureStressReproduceRates
-      m_HashValue: 795492441
-    LabelId:
-      m_Source: jobs.coral-hunting-lions.task.measureStressReproduceRates
-      m_HashValue: 651488821
-    Category: 3
-    Steps:
-    - Type: 1
-      Target:
-        m_Source: StaghornCoral.Reproduce
-        m_HashValue: 3964275685
-      ConditionString: 
-      Amount: 0
-    - Type: 1
-      Target:
-        m_Source: BlueheadWrasse.Reproduce
-        m_HashValue: 1563920227
-      ConditionString: 
-      Amount: 0
-    - Type: 1
-      Target:
-        m_Source: BlueTang.Reproduce
-        m_HashValue: 427368968
-      ConditionString: 
-      Amount: 0
-    - Type: 1
-      Target:
-        m_Source: Lionfish.Reproduce
-        m_HashValue: 3773007000
-      ConditionString: 
-      Amount: 0
-    - Type: 1
-      Target:
-        m_Source: TurfAlgae.Reproduce
-        m_HashValue: 1199979687
-      ConditionString: 
-      Amount: 0
-    - Type: 1
-      Target:
-        m_Source: Sargassum.Reproduce
-        m_HashValue: 3860466180
-      ConditionString: 
-      Amount: 0
-    - Type: 1
-      Target:
-        m_Source: Ick.Reproduce
-        m_HashValue: 516665143
-      ConditionString: 
-      Amount: 0
-    PrerequisiteTaskIds:
-    - m_Source: measureEatRates
-      m_HashValue: 1302348262
-  - Id:
       m_Source: obtainStressRules
       m_HashValue: 3804672883
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.obtainStressRules
       m_HashValue: 1076555463
     Category: 3
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -424,12 +383,69 @@ MonoBehaviour:
     - m_Source: observeEatRules
       m_HashValue: 4279728306
   - Id:
+      m_Source: measureStressReproduceRates
+      m_HashValue: 795492441
+    LabelId:
+      m_Source: jobs.coral-hunting-lions.task.measureStressReproduceRates
+      m_HashValue: 651488821
+    Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
+    Steps:
+    - Type: 1
+      Target:
+        m_Source: StaghornCoral.Reproduce
+        m_HashValue: 3964275685
+      ConditionString: 
+      Amount: 0
+    - Type: 1
+      Target:
+        m_Source: BlueheadWrasse.Reproduce
+        m_HashValue: 1563920227
+      ConditionString: 
+      Amount: 0
+    - Type: 1
+      Target:
+        m_Source: BlueTang.Reproduce
+        m_HashValue: 427368968
+      ConditionString: 
+      Amount: 0
+    - Type: 1
+      Target:
+        m_Source: Lionfish.Reproduce
+        m_HashValue: 3773007000
+      ConditionString: 
+      Amount: 0
+    - Type: 1
+      Target:
+        m_Source: TurfAlgae.Reproduce
+        m_HashValue: 1199979687
+      ConditionString: 
+      Amount: 0
+    - Type: 1
+      Target:
+        m_Source: Sargassum.Reproduce
+        m_HashValue: 3860466180
+      ConditionString: 
+      Amount: 0
+    - Type: 1
+      Target:
+        m_Source: Ick.Reproduce
+        m_HashValue: 516665143
+      ConditionString: 
+      Amount: 0
+    PrerequisiteTaskIds:
+    - m_Source: measureEatRates
+      m_HashValue: 1302348262
+  - Id:
       m_Source: obtainChemistry
       m_HashValue: 1751383414
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.obtainChemistry
       m_HashValue: 2308555914
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -531,6 +547,8 @@ MonoBehaviour:
       m_Source: jobs.coral-hunting-lions.task.predictModel
       m_HashValue: 4179720499
     Category: 4
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -548,6 +566,8 @@ MonoBehaviour:
       m_Source: jobs.coral-hunting-lions.task.interveneModel
       m_HashValue: 113021158
     Category: 4
+    TaskComplexity: 3
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 1
       Target:
@@ -565,6 +585,8 @@ MonoBehaviour:
       m_Source: jobs.coral-hunting-lions.task.argueIncentive
       m_HashValue: 1939686082
     Category: 5
+    TaskComplexity: 3
+    ScaffoldingComplexity: 3
     Steps:
     - Type: 10
       Target:
@@ -584,6 +606,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.countPopulation
       m_HashValue: 3885012231
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -630,6 +654,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.observeEatRules
       m_HashValue: 826814686
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -664,6 +690,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.obtainStressRules
       m_HashValue: 1076555463
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -782,6 +810,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.measureEatRates
       m_HashValue: 1847961002
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 2
       Target:
@@ -816,6 +846,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.measureStressReproduceRates
       m_HashValue: 651488821
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -868,6 +900,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.obtainChemistry
       m_HashValue: 2308555914
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -968,6 +1002,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.predictModel
       m_HashValue: 4179720499
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -984,6 +1020,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.interveneModel
       m_HashValue: 113021158
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -1000,6 +1038,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.scanCritters
       m_HashValue: 1635544448
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -1064,6 +1104,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.scanHistory
       m_HashValue: 32716956
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -1086,6 +1128,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.argueIncentive
       m_HashValue: 1939686082
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-hunting-lions/coral-hunting-lions.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-hunting-lions/coral-hunting-lions.asset
@@ -606,8 +606,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.countPopulation
       m_HashValue: 3885012231
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -654,8 +652,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.observeEatRules
       m_HashValue: 826814686
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -690,8 +686,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.obtainStressRules
       m_HashValue: 1076555463
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -810,8 +804,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.measureEatRates
       m_HashValue: 1847961002
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 2
       Target:
@@ -846,8 +838,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.measureStressReproduceRates
       m_HashValue: 651488821
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -900,8 +890,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.obtainChemistry
       m_HashValue: 2308555914
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -1002,8 +990,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.predictModel
       m_HashValue: 4179720499
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -1020,8 +1006,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.interveneModel
       m_HashValue: 113021158
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -1038,8 +1022,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.scanCritters
       m_HashValue: 1635544448
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -1104,8 +1086,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.scanHistory
       m_HashValue: 32716956
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -1128,8 +1108,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-hunting-lions.task.argueIncentive
       m_HashValue: 1939686082
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-lionfish-conspiracy/coral-lionfish-conspiracy.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-lionfish-conspiracy/coral-lionfish-conspiracy.asset
@@ -146,8 +146,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.lionfish-conspiracy.task.scanNew
       m_HashValue: 1751479097
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -176,8 +174,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.lionfish-conspiracy.task.observeCoral
       m_HashValue: 3645962509
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 6
       Target:
@@ -194,8 +190,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.lionfish-conspiracy.task.observeInteractions
       m_HashValue: 1611676689
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -218,8 +212,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.lionfish-conspiracy.task.arguePredator
       m_HashValue: 2507088081
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-lionfish-conspiracy/coral-lionfish-conspiracy.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-lionfish-conspiracy/coral-lionfish-conspiracy.asset
@@ -52,6 +52,8 @@ MonoBehaviour:
       m_Source: jobs.lionfish-conspiracy.task.scanNew
       m_HashValue: 1751479097
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -79,6 +81,8 @@ MonoBehaviour:
       m_Source: jobs.lionfish-conspiracy.task.observeCoral
       m_HashValue: 3645962509
     Category: 3
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 6
       Target:
@@ -96,6 +100,8 @@ MonoBehaviour:
       m_Source: jobs.lionfish-conspiracy.task.observeInteractions
       m_HashValue: 1611676689
     Category: 3
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -119,6 +125,8 @@ MonoBehaviour:
       m_Source: jobs.lionfish-conspiracy.task.arguePredator
       m_HashValue: 2507088081
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -138,6 +146,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.lionfish-conspiracy.task.scanNew
       m_HashValue: 1751479097
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -166,6 +176,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.lionfish-conspiracy.task.observeCoral
       m_HashValue: 3645962509
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 6
       Target:
@@ -182,6 +194,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.lionfish-conspiracy.task.observeInteractions
       m_HashValue: 1611676689
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -204,6 +218,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.lionfish-conspiracy.task.arguePredator
       m_HashValue: 2507088081
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-lionfish-conspiracy/coral-lionfish-conspiracy.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-lionfish-conspiracy/coral-lionfish-conspiracy.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 1
   m_ExperimentDifficulty: 1
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 3

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-much-algae/coral-much-algae.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-much-algae/coral-much-algae.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: jobs.coral-much-algae.desc.short
     m_HashValue: 1710466208
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 3
   m_ModelingDifficulty: 3
   m_ArgumentationDifficulty: 3

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-much-algae/coral-much-algae.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-much-algae/coral-much-algae.asset
@@ -54,6 +54,8 @@ MonoBehaviour:
       m_Source: jobs.coral-much-algae.task.scanAll
       m_HashValue: 4177088458
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -105,6 +107,8 @@ MonoBehaviour:
       m_Source: jobs.coral-much-algae.task.histPop
       m_HashValue: 490860265
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -134,6 +138,8 @@ MonoBehaviour:
       m_Source: jobs.coral-much-algae.task.observeEatAlgae
       m_HashValue: 2455171404
     Category: 3
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -151,6 +157,8 @@ MonoBehaviour:
       m_Source: jobs.coral-much-algae.task.measureEatRate
       m_HashValue: 3402110470
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 2
       Target:
@@ -168,6 +176,8 @@ MonoBehaviour:
       m_Source: jobs.coral-much-algae.task.modelPopulations
       m_HashValue: 833603665
     Category: 4
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 1
       Target:
@@ -185,6 +195,8 @@ MonoBehaviour:
       m_Source: jobs.coral-much-algae.task.reportBack
       m_HashValue: 2999981227
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 10
       Target:
@@ -204,6 +216,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-much-algae.task.scanAll
       m_HashValue: 4177088458
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -256,6 +270,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-much-algae.task.observeEatAlgae
       m_HashValue: 2455171404
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -272,6 +288,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-much-algae.task.measureEatRate
       m_HashValue: 3402110470
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 2
       Target:
@@ -288,6 +306,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-much-algae.task.modelPopulations
       m_HashValue: 833603665
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -304,6 +324,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-much-algae.task.histPop
       m_HashValue: 490860265
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -332,6 +354,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-much-algae.task.reportBack
       m_HashValue: 2999981227
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-much-algae/coral-much-algae.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-much-algae/coral-much-algae.asset
@@ -216,8 +216,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-much-algae.task.scanAll
       m_HashValue: 4177088458
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -270,8 +268,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-much-algae.task.observeEatAlgae
       m_HashValue: 2455171404
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -288,8 +284,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-much-algae.task.measureEatRate
       m_HashValue: 3402110470
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 2
       Target:
@@ -306,8 +300,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-much-algae.task.modelPopulations
       m_HashValue: 833603665
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -324,8 +316,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-much-algae.task.histPop
       m_HashValue: 490860265
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -354,8 +344,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-much-algae.task.reportBack
       m_HashValue: 2999981227
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-ocean-plastics/coral-ocean-plastics.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-ocean-plastics/coral-ocean-plastics.asset
@@ -153,8 +153,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-ocean-plastics.task.scanReefEdge
       m_HashValue: 246783840
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -195,8 +193,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-ocean-plastics.task.whatTurtlesEat
       m_HashValue: 823957611
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -231,8 +227,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-ocean-plastics.task.reportBack
       m_HashValue: 4040639279
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-ocean-plastics/coral-ocean-plastics.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-ocean-plastics/coral-ocean-plastics.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 1
   m_ExperimentDifficulty: 2
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 1

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-ocean-plastics/coral-ocean-plastics.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-ocean-plastics/coral-ocean-plastics.asset
@@ -54,6 +54,8 @@ MonoBehaviour:
       m_Source: jobs.coral-ocean-plastics.task.scanReefEdge
       m_HashValue: 246783840
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -93,6 +95,8 @@ MonoBehaviour:
       m_Source: jobs.coral-ocean-plastics.task.whatTurtlesEat
       m_HashValue: 823957611
     Category: 3
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -128,6 +132,8 @@ MonoBehaviour:
       m_Source: jobs.coral-ocean-plastics.task.reportBack
       m_HashValue: 4040639279
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 10
       Target:
@@ -147,6 +153,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-ocean-plastics.task.scanReefEdge
       m_HashValue: 246783840
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -187,6 +195,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-ocean-plastics.task.whatTurtlesEat
       m_HashValue: 823957611
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -221,6 +231,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-ocean-plastics.task.reportBack
       m_HashValue: 4040639279
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-stressed/coral-stressed.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-stressed/coral-stressed.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 2
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 4

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-stressed/coral-stressed.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-stressed/coral-stressed.asset
@@ -117,8 +117,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-stressed.task.SiteR
       m_HashValue: 2734975974
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -141,8 +139,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-stressed.task.stressCoral
       m_HashValue: 794925384
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -159,8 +155,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-stressed.task.reportBack
       m_HashValue: 429467298
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-stressed/coral-stressed.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-stressed/coral-stressed.asset
@@ -54,6 +54,8 @@ MonoBehaviour:
       m_Source: jobs.coral-stressed.task.SiteR
       m_HashValue: 2734975974
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -75,6 +77,8 @@ MonoBehaviour:
       m_Source: jobs.coral-stressed.task.stressCoral
       m_HashValue: 794925384
     Category: 3
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 1
       Target:
@@ -92,6 +96,8 @@ MonoBehaviour:
       m_Source: jobs.coral-stressed.task.reportBack
       m_HashValue: 429467298
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 10
       Target:
@@ -111,6 +117,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-stressed.task.SiteR
       m_HashValue: 2734975974
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -133,6 +141,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-stressed.task.stressCoral
       m_HashValue: 794925384
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -149,6 +159,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-stressed.task.reportBack
       m_HashValue: 429467298
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-tang-checkup/coral-tang-checkup.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-tang-checkup/coral-tang-checkup.asset
@@ -186,8 +186,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-check-up.task.findStress
       m_HashValue: 828071247
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -216,8 +214,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-check-up.task.findMicro
       m_HashValue: 971912509
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -234,8 +230,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-check-up.task.countIck
       m_HashValue: 3346759308
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -252,8 +246,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-check-up.task.observeIck
       m_HashValue: 4211324833
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -270,8 +262,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-check-up.task.reviseVisual
       m_HashValue: 1895454920
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -294,8 +284,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-check-up.task.report
       m_HashValue: 3562548038
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-tang-checkup/coral-tang-checkup.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-tang-checkup/coral-tang-checkup.asset
@@ -48,12 +48,52 @@ MonoBehaviour:
   - m_HashValue: 2212791738
   m_Tasks:
   - Id:
+      m_Source: findMicro
+      m_HashValue: 3884350846
+    LabelId:
+      m_Source: jobs.coral-check-up.task.findMicro
+      m_HashValue: 971912509
+    Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
+    Steps:
+    - Type: 0
+      Target:
+        m_Source: Ick
+        m_HashValue: 3815586090
+      ConditionString: 
+      Amount: 0
+    PrerequisiteTaskIds:
+    - m_Source: findStress
+      m_HashValue: 4156621478
+  - Id:
+      m_Source: countIck
+      m_HashValue: 2900031109
+    LabelId:
+      m_Source: jobs.coral-check-up.task.countIck
+      m_HashValue: 3346759308
+    Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
+    Steps:
+    - Type: 1
+      Target:
+        m_Source: LionfishInvasion.Population.Ick
+        m_HashValue: 1380939620
+      ConditionString: 
+      Amount: 0
+    PrerequisiteTaskIds:
+    - m_Source: findMicro
+      m_HashValue: 3884350846
+  - Id:
       m_Source: findStress
       m_HashValue: 4156621478
     LabelId:
       m_Source: jobs.coral-check-up.task.findStress
       m_HashValue: 828071247
     Category: 3
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -75,46 +115,14 @@ MonoBehaviour:
       Amount: 0
     PrerequisiteTaskIds: []
   - Id:
-      m_Source: findMicro
-      m_HashValue: 3884350846
-    LabelId:
-      m_Source: jobs.coral-check-up.task.findMicro
-      m_HashValue: 971912509
-    Category: 2
-    Steps:
-    - Type: 0
-      Target:
-        m_Source: Ick
-        m_HashValue: 3815586090
-      ConditionString: 
-      Amount: 0
-    PrerequisiteTaskIds:
-    - m_Source: findStress
-      m_HashValue: 4156621478
-  - Id:
-      m_Source: countIck
-      m_HashValue: 2900031109
-    LabelId:
-      m_Source: jobs.coral-check-up.task.countIck
-      m_HashValue: 3346759308
-    Category: 2
-    Steps:
-    - Type: 1
-      Target:
-        m_Source: LionfishInvasion.Population.Ick
-        m_HashValue: 1380939620
-      ConditionString: 
-      Amount: 0
-    PrerequisiteTaskIds:
-    - m_Source: findMicro
-      m_HashValue: 3884350846
-  - Id:
       m_Source: observeIck
       m_HashValue: 3336794152
     LabelId:
       m_Source: jobs.coral-check-up.task.observeIck
       m_HashValue: 4211324833
     Category: 3
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -132,6 +140,8 @@ MonoBehaviour:
       m_Source: jobs.coral-check-up.task.reviseVisual
       m_HashValue: 1895454920
     Category: 4
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -155,6 +165,8 @@ MonoBehaviour:
       m_Source: jobs.coral-check-up.task.report
       m_HashValue: 3562548038
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -174,6 +186,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-check-up.task.findStress
       m_HashValue: 828071247
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -202,6 +216,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-check-up.task.findMicro
       m_HashValue: 971912509
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -218,6 +234,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-check-up.task.countIck
       m_HashValue: 3346759308
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -234,6 +252,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-check-up.task.observeIck
       m_HashValue: 4211324833
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -250,6 +270,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-check-up.task.reviseVisual
       m_HashValue: 1895454920
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -272,6 +294,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-check-up.task.report
       m_HashValue: 3562548038
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-tang-checkup/coral-tang-checkup.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-tang-checkup/coral-tang-checkup.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 3
   m_ExperimentDifficulty: 3
   m_ModelingDifficulty: 3
   m_ArgumentationDifficulty: 2

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-turtle-population/coral-turtle-population.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-turtle-population/coral-turtle-population.asset
@@ -50,6 +50,8 @@ MonoBehaviour:
       m_Source: jobs.coral-turtle-population.task.scanTurtle
       m_HashValue: 216022589
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -65,6 +67,8 @@ MonoBehaviour:
       m_Source: jobs.coral-turtle-population.task.countTurtle
       m_HashValue: 1881211707
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -82,6 +86,8 @@ MonoBehaviour:
       m_Source: jobs.coral-turtle-population.task.reportBack
       m_HashValue: 1159626771
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -101,6 +107,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-turtle-population.task.scanTurtle
       m_HashValue: 216022589
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -117,6 +125,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-turtle-population.task.countTurtle
       m_HashValue: 1881211707
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -133,6 +143,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-turtle-population.task.reportBack
       m_HashValue: 1159626771
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-turtle-population/coral-turtle-population.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-turtle-population/coral-turtle-population.asset
@@ -107,8 +107,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-turtle-population.task.scanTurtle
       m_HashValue: 216022589
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -125,8 +123,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-turtle-population.task.countTurtle
       m_HashValue: 1881211707
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -143,8 +139,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-turtle-population.task.reportBack
       m_HashValue: 1159626771
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-turtle-population/coral-turtle-population.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-turtle-population/coral-turtle-population.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 0
   m_ExperimentDifficulty: 0
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 1

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-turtle-stability/coral-turtle-stability.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-turtle-stability/coral-turtle-stability.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 1
   m_ExperimentDifficulty: 1
   m_ModelingDifficulty: 1
   m_ArgumentationDifficulty: 1

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-turtle-stability/coral-turtle-stability.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-turtle-stability/coral-turtle-stability.asset
@@ -51,6 +51,8 @@ MonoBehaviour:
       m_Source: jobs.coral-turtle-stability.task.SiteV
       m_HashValue: 3770236753
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -90,6 +92,8 @@ MonoBehaviour:
       m_Source: jobs.coral-turtle-stability.task.scanTurtle
       m_HashValue: 1327499417
     Category: 3
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 1
       Target:
@@ -119,6 +123,8 @@ MonoBehaviour:
       m_Source: jobs.coral-turtle-stability.task.turtleModel
       m_HashValue: 503602137
     Category: 4
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 1
       Target:
@@ -136,6 +142,8 @@ MonoBehaviour:
       m_Source: jobs.coral-turtle-stability.task.reportBack
       m_HashValue: 3158413991
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -155,6 +163,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-turtle-stability.task.SiteV
       m_HashValue: 3770236753
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -195,6 +205,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-turtle-stability.task.scanTurtle
       m_HashValue: 1327499417
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -223,6 +235,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-turtle-stability.task.turtleModel
       m_HashValue: 503602137
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -239,6 +253,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-turtle-stability.task.reportBack
       m_HashValue: 3158413991
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/CoralStationJobs/coral-turtle-stability/coral-turtle-stability.asset
+++ b/Assets/_Content/Jobs/CoralStationJobs/coral-turtle-stability/coral-turtle-stability.asset
@@ -163,8 +163,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-turtle-stability.task.SiteV
       m_HashValue: 3770236753
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -205,8 +203,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-turtle-stability.task.scanTurtle
       m_HashValue: 1327499417
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -235,8 +231,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-turtle-stability.task.turtleModel
       m_HashValue: 503602137
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -253,8 +247,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.coral-turtle-stability.task.reportBack
       m_HashValue: 3158413991
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/FinalStationJobs/final-final/final-final.asset
+++ b/Assets/_Content/Jobs/FinalStationJobs/final-final/final-final.asset
@@ -50,6 +50,8 @@ MonoBehaviour:
       m_Source: jobs.final-final.task.tellMom
       m_HashValue: 3323484621
     Category: 6
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 6
       Target:
@@ -65,6 +67,8 @@ MonoBehaviour:
       m_Source: jobs.final-final.task.createModel
       m_HashValue: 1111136982
     Category: 4
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -82,6 +86,8 @@ MonoBehaviour:
       m_Source: jobs.final-final.task.reportBack
       m_HashValue: 377457624
     Category: 5
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:
@@ -99,6 +105,8 @@ MonoBehaviour:
       m_Source: jobs.final-final.task.sneakOut
       m_HashValue: 1168020589
     Category: 6
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 6
       Target:
@@ -116,6 +124,8 @@ MonoBehaviour:
       m_Source: jobs.final-final.task.getUncleHelp
       m_HashValue: 3013625325
     Category: 6
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 6
       Target:
@@ -133,6 +143,8 @@ MonoBehaviour:
       m_Source: jobs.final-final.task.checkShip
       m_HashValue: 1192926505
     Category: 6
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 6
       Target:
@@ -150,6 +162,8 @@ MonoBehaviour:
       m_Source: jobs.final-final.task.performRescue
       m_HashValue: 3321614251
     Category: 6
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 6
       Target:

--- a/Assets/_Content/Jobs/FinalStationJobs/final-final/final-final.asset
+++ b/Assets/_Content/Jobs/FinalStationJobs/final-final/final-final.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 0
   m_ExperimentDifficulty: 0
   m_ModelingDifficulty: 2
   m_ArgumentationDifficulty: 4

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-bull-kelp-forest/kelp-bull-kelp-forest.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-bull-kelp-forest/kelp-bull-kelp-forest.asset
@@ -51,6 +51,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-bull-kelp-forest.task.siteA
       m_HashValue: 2169305873
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -66,6 +68,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-bull-kelp-forest.task.foodweb
       m_HashValue: 1120255105
     Category: 3
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -83,6 +87,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-bull-kelp-forest.task.reportBack
       m_HashValue: 1189211000
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -102,6 +108,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-bull-kelp-forest.task.siteA
       m_HashValue: 2169305873
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -118,6 +126,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-bull-kelp-forest.task.foodweb
       m_HashValue: 1120255105
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -134,6 +144,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-bull-kelp-forest.task.reportBack
       m_HashValue: 1189211000
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-bull-kelp-forest/kelp-bull-kelp-forest.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-bull-kelp-forest/kelp-bull-kelp-forest.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 1
   m_ExperimentDifficulty: 1
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 1

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-bull-kelp-forest/kelp-bull-kelp-forest.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-bull-kelp-forest/kelp-bull-kelp-forest.asset
@@ -108,8 +108,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-bull-kelp-forest.task.siteA
       m_HashValue: 2169305873
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -126,8 +124,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-bull-kelp-forest.task.foodweb
       m_HashValue: 1120255105
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -144,8 +140,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-bull-kelp-forest.task.reportBack
       m_HashValue: 1189211000
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-energy/kelp-energy.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-energy/kelp-energy.asset
@@ -50,6 +50,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-energy.task.model
       m_HashValue: 4169997988
     Category: 4
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 1
       Target:
@@ -65,6 +67,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-bull-kelp-forest.task.reportBack
       m_HashValue: 1189211000
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -84,6 +88,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-energy.task.model
       m_HashValue: 4169997988
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -100,6 +106,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-bull-kelp-forest.task.reportBack
       m_HashValue: 1189211000
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-energy/kelp-energy.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-energy/kelp-energy.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 1
   m_ExperimentDifficulty: 0
   m_ModelingDifficulty: 1
   m_ArgumentationDifficulty: 1

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-energy/kelp-energy.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-energy/kelp-energy.asset
@@ -88,8 +88,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-energy.task.model
       m_HashValue: 4169997988
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -106,8 +104,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-bull-kelp-forest.task.reportBack
       m_HashValue: 1189211000
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-mussel-fest/kelp-mussel-fest.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-mussel-fest/kelp-mussel-fest.asset
@@ -55,6 +55,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-mussel-fest.task.scanMussels
       m_HashValue: 4098094746
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -70,6 +72,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-mussel-fest.task.waterData
       m_HashValue: 1152367680
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -97,6 +101,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-mussel-fest.task.stressParam
       m_HashValue: 2006971082
     Category: 3
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -128,6 +134,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-mussel-fest.task.report
       m_HashValue: 624845683
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -147,6 +155,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-mussel-fest.task.scanMussels
       m_HashValue: 4098094746
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -163,6 +173,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-mussel-fest.task.waterData
       m_HashValue: 1152367680
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -191,6 +203,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-mussel-fest.task.stressParam
       m_HashValue: 2006971082
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -219,6 +233,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-mussel-fest.task.report
       m_HashValue: 624845683
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-mussel-fest/kelp-mussel-fest.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-mussel-fest/kelp-mussel-fest.asset
@@ -155,8 +155,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-mussel-fest.task.scanMussels
       m_HashValue: 4098094746
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -173,8 +171,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-mussel-fest.task.waterData
       m_HashValue: 1152367680
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -203,8 +199,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-mussel-fest.task.stressParam
       m_HashValue: 2006971082
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -233,8 +227,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-mussel-fest.task.report
       m_HashValue: 624845683
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-mussel-fest/kelp-mussel-fest.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-mussel-fest/kelp-mussel-fest.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 2
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 2

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-musselfest-solution/kelp-musselfest-solution.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-musselfest-solution/kelp-musselfest-solution.asset
@@ -111,8 +111,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-mussel-fest-solution.task.unstressedRate
       m_HashValue: 1253920849
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -129,8 +127,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-mussel-fest-solution.task.stressedRate
       m_HashValue: 729657490
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -147,8 +143,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-mussel-fest-solution.task.reportChange
       m_HashValue: 106659395
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-musselfest-solution/kelp-musselfest-solution.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-musselfest-solution/kelp-musselfest-solution.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 3
   m_ExperimentDifficulty: 2
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 3

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-musselfest-solution/kelp-musselfest-solution.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-musselfest-solution/kelp-musselfest-solution.asset
@@ -52,6 +52,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-mussel-fest-solution.task.unstressedRate
       m_HashValue: 1253920849
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -67,6 +69,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-mussel-fest-solution.task.stressedRate
       m_HashValue: 729657490
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -84,6 +88,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-mussel-fest-solution.task.reportChange
       m_HashValue: 106659395
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 10
       Target:
@@ -105,6 +111,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-mussel-fest-solution.task.unstressedRate
       m_HashValue: 1253920849
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -121,6 +129,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-mussel-fest-solution.task.stressedRate
       m_HashValue: 729657490
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -137,6 +147,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-mussel-fest-solution.task.reportChange
       m_HashValue: 106659395
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-refuge-failure-simulation/kelp-refuge-failure-simulation.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-refuge-failure-simulation/kelp-refuge-failure-simulation.asset
@@ -90,8 +90,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure-simulation.task.createModel
       m_HashValue: 2291614983
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -108,8 +106,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure-simulation.task.shareModel
       m_HashValue: 3683645354
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-refuge-failure-simulation/kelp-refuge-failure-simulation.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-refuge-failure-simulation/kelp-refuge-failure-simulation.asset
@@ -52,6 +52,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-refuge-failure-simulation.task.createModel
       m_HashValue: 2291614983
     Category: 4
+    TaskComplexity: 2
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -67,6 +69,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-refuge-failure-simulation.task.shareModel
       m_HashValue: 3683645354
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -86,6 +90,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure-simulation.task.createModel
       m_HashValue: 2291614983
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -102,6 +108,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure-simulation.task.shareModel
       m_HashValue: 3683645354
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-refuge-failure-simulation/kelp-refuge-failure-simulation.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-refuge-failure-simulation/kelp-refuge-failure-simulation.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 0
   m_ModelingDifficulty: 4
   m_ArgumentationDifficulty: 1

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-refuge-failure/kelp-refuge-failure.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-refuge-failure/kelp-refuge-failure.asset
@@ -271,8 +271,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure.task.visitSite
       m_HashValue: 3160486164
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 3
       Target:
@@ -289,8 +287,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure.task.histPop
       m_HashValue: 733026455
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -313,8 +309,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure.task.histChem
       m_HashValue: 3797461213
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -343,8 +337,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure.task.growthRates
       m_HashValue: 2881083366
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -367,8 +359,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure.task.growthRatesBull
       m_HashValue: 252314555
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -391,8 +381,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure.task.lightRatesGiant
       m_HashValue: 1378242856
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -409,8 +397,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure.task.lightRatesBull
       m_HashValue: 3285731570
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -427,8 +413,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure.task.newModel
       m_HashValue: 2830310567
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -445,8 +429,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure.task.getPaid
       m_HashValue: 3159939990
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-refuge-failure/kelp-refuge-failure.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-refuge-failure/kelp-refuge-failure.asset
@@ -54,6 +54,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-refuge-failure.task.visitSite
       m_HashValue: 3160486164
     Category: 1
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 3
       Target:
@@ -69,6 +71,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-refuge-failure.task.histPop
       m_HashValue: 733026455
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -92,6 +96,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-refuge-failure.task.histChem
       m_HashValue: 3797461213
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -121,6 +127,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-refuge-failure.task.growthRates
       m_HashValue: 2881083366
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 1
       Target:
@@ -146,6 +154,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-refuge-failure.task.growthRatesBull
       m_HashValue: 252314555
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 1
       Target:
@@ -171,6 +181,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-refuge-failure.task.lightRatesGiant
       m_HashValue: 1378242856
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 1
       Target:
@@ -190,6 +202,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-refuge-failure.task.lightRatesBull
       m_HashValue: 3285731570
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 1
       Target:
@@ -209,6 +223,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-refuge-failure.task.newModel
       m_HashValue: 2830310567
     Category: 4
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 1
       Target:
@@ -234,6 +250,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-refuge-failure.task.getPaid
       m_HashValue: 3159939990
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 3
     Steps:
     - Type: 10
       Target:
@@ -253,6 +271,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure.task.visitSite
       m_HashValue: 3160486164
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 3
       Target:
@@ -269,6 +289,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure.task.histPop
       m_HashValue: 733026455
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -291,6 +313,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure.task.histChem
       m_HashValue: 3797461213
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -319,6 +343,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure.task.growthRates
       m_HashValue: 2881083366
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -341,6 +367,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure.task.growthRatesBull
       m_HashValue: 252314555
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -363,6 +391,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure.task.lightRatesGiant
       m_HashValue: 1378242856
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -379,6 +409,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure.task.lightRatesBull
       m_HashValue: 3285731570
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -395,6 +427,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure.task.newModel
       m_HashValue: 2830310567
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -411,6 +445,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-refuge-failure.task.getPaid
       m_HashValue: 3159939990
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-refuge-failure/kelp-refuge-failure.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-refuge-failure/kelp-refuge-failure.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 4
   m_ModelingDifficulty: 3
   m_ArgumentationDifficulty: 3

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-save-urchin-barren/kelp-save-urchin-barren.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-save-urchin-barren/kelp-save-urchin-barren.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 0
   m_ModelingDifficulty: 4
   m_ArgumentationDifficulty: 2

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-save-urchin-barren/kelp-save-urchin-barren.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-save-urchin-barren/kelp-save-urchin-barren.asset
@@ -52,6 +52,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-save-urchin-barren.task.makeAPlan
       m_HashValue: 642567
     Category: 4
+    TaskComplexity: 3
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 1
       Target:
@@ -67,6 +69,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-save-urchin-barren.task.return
       m_HashValue: 1731407629
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -86,6 +90,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-save-urchin-barren.task.makeAPlan
       m_HashValue: 642567
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -102,6 +108,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-save-urchin-barren.task.return
       m_HashValue: 1731407629
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-save-urchin-barren/kelp-save-urchin-barren.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-save-urchin-barren/kelp-save-urchin-barren.asset
@@ -90,8 +90,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-save-urchin-barren.task.makeAPlan
       m_HashValue: 642567
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -108,8 +106,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-save-urchin-barren.task.return
       m_HashValue: 1731407629
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-shop-welcome/kelp-shop-welcome.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-shop-welcome/kelp-shop-welcome.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 0
   m_ExperimentDifficulty: 0
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 0

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-start-refuge/kelp-start-refuge.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-start-refuge/kelp-start-refuge.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: jobs.kelp-start-refuge.desc.short
     m_HashValue: 327449134
+  m_TopicComplexity: 2
   m_ExperimentDifficulty: 2
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 4

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-start-refuge/kelp-start-refuge.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-start-refuge/kelp-start-refuge.asset
@@ -122,8 +122,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-start-refuge.task.getBullKelpStress
       m_HashValue: 4280061809
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -146,8 +144,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-start-refuge.task.getGiantKelpStress
       m_HashValue: 3559721285
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -170,8 +166,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-start-refuge.task.argueSite
       m_HashValue: 2753005113
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-start-refuge/kelp-start-refuge.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-start-refuge/kelp-start-refuge.asset
@@ -53,6 +53,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-start-refuge.task.getBullKelpStress
       m_HashValue: 4280061809
     Category: 3
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 1
       Target:
@@ -74,6 +76,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-start-refuge.task.getGiantKelpStress
       m_HashValue: 3559721285
     Category: 3
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 1
       Target:
@@ -95,6 +99,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-start-refuge.task.argueSite
       m_HashValue: 2753005113
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -116,6 +122,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-start-refuge.task.getBullKelpStress
       m_HashValue: 4280061809
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -138,6 +146,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-start-refuge.task.getGiantKelpStress
       m_HashValue: 3559721285
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -160,6 +170,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-start-refuge.task.argueSite
       m_HashValue: 2753005113
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-urchin-barren-predict/kelp-urchin-barren-predict.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-urchin-barren-predict/kelp-urchin-barren-predict.asset
@@ -90,8 +90,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-barren-predict.task.predictSiteB
       m_HashValue: 3612134323
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -108,8 +106,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-barren-predict.task.reportBack
       m_HashValue: 134852686
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-urchin-barren-predict/kelp-urchin-barren-predict.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-urchin-barren-predict/kelp-urchin-barren-predict.asset
@@ -52,6 +52,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-urchin-barren-predict.task.predictSiteB
       m_HashValue: 3612134323
     Category: 4
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 1
       Target:
@@ -67,6 +69,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-urchin-barren-predict.task.reportBack
       m_HashValue: 134852686
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -86,6 +90,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-barren-predict.task.predictSiteB
       m_HashValue: 3612134323
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -102,6 +108,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-barren-predict.task.reportBack
       m_HashValue: 134852686
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-urchin-barren-predict/kelp-urchin-barren-predict.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-urchin-barren-predict/kelp-urchin-barren-predict.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 1
   m_ExperimentDifficulty: 0
   m_ModelingDifficulty: 3
   m_ArgumentationDifficulty: 1

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-urchin-barren-viz/kelp-urchin-barren-viz.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-urchin-barren-viz/kelp-urchin-barren-viz.asset
@@ -54,6 +54,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-urchin-barren-viz.task.gotoSiteB
       m_HashValue: 1232398739
     Category: 1
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 3
       Target:
@@ -69,6 +71,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-urchin-barren-viz.task.getProbeData
       m_HashValue: 3775884441
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -92,6 +96,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-urchin-barren-viz.task.getTagged
       m_HashValue: 3478965733
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -115,6 +121,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-urchin-barren-viz.task.visualSiteB
       m_HashValue: 565883666
     Category: 4
+    TaskComplexity: 1
+    ScaffoldingComplexity: 2
     Steps:
     - Type: 1
       Target:
@@ -134,6 +142,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-urchin-barren-viz.task.reportBack
       m_HashValue: 1058725242
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -155,6 +165,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-barren-viz.task.gotoSiteB
       m_HashValue: 1232398739
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 3
       Target:
@@ -171,6 +183,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-barren-viz.task.getProbeData
       m_HashValue: 3775884441
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -193,6 +207,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-barren-viz.task.getTagged
       m_HashValue: 3478965733
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -215,6 +231,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-barren-viz.task.visualSiteB
       m_HashValue: 565883666
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -231,6 +249,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-barren-viz.task.reportBack
       m_HashValue: 1058725242
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-urchin-barren-viz/kelp-urchin-barren-viz.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-urchin-barren-viz/kelp-urchin-barren-viz.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 1
   m_ExperimentDifficulty: 0
   m_ModelingDifficulty: 1
   m_ArgumentationDifficulty: 1

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-urchin-barren-viz/kelp-urchin-barren-viz.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-urchin-barren-viz/kelp-urchin-barren-viz.asset
@@ -165,8 +165,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-barren-viz.task.gotoSiteB
       m_HashValue: 1232398739
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 3
       Target:
@@ -183,8 +181,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-barren-viz.task.getProbeData
       m_HashValue: 3775884441
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -207,8 +203,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-barren-viz.task.getTagged
       m_HashValue: 3478965733
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -231,8 +225,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-barren-viz.task.visualSiteB
       m_HashValue: 565883666
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -249,8 +241,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-barren-viz.task.reportBack
       m_HashValue: 1058725242
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-urchin-farm/kelp-urchin-farm.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-urchin-farm/kelp-urchin-farm.asset
@@ -53,6 +53,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-urchin-farm.task.urchinEatBull
       m_HashValue: 2008727161
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 2
       Target:
@@ -68,6 +70,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-urchin-farm.task.urchinEatGiant
       m_HashValue: 1387438373
     Category: 3
+    TaskComplexity: 3
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 2
       Target:
@@ -83,6 +87,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-urchin-farm.task.reportBack
       m_HashValue: 1297576520
     Category: 5
+    TaskComplexity: 2
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -104,6 +110,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-farm.task.urchinEatBull
       m_HashValue: 2008727161
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 2
       Target:
@@ -120,6 +128,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-farm.task.urchinEatGiant
       m_HashValue: 1387438373
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 2
       Target:
@@ -136,6 +146,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-farm.task.reportBack
       m_HashValue: 1297576520
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-urchin-farm/kelp-urchin-farm.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-urchin-farm/kelp-urchin-farm.asset
@@ -110,8 +110,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-farm.task.urchinEatBull
       m_HashValue: 2008727161
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 2
       Target:
@@ -128,8 +126,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-farm.task.urchinEatGiant
       m_HashValue: 1387438373
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 2
       Target:
@@ -146,8 +142,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-urchin-farm.task.reportBack
       m_HashValue: 1297576520
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-urchin-farm/kelp-urchin-farm.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-urchin-farm/kelp-urchin-farm.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 1
   m_ExperimentDifficulty: 3
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 4

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-welcome/kelp-welcome.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-welcome/kelp-welcome.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   m_DescShortId:
     m_Source: 
     m_HashValue: 0
+  m_TopicComplexity: 1
   m_ExperimentDifficulty: 1
   m_ModelingDifficulty: 0
   m_ArgumentationDifficulty: 1

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-welcome/kelp-welcome.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-welcome/kelp-welcome.asset
@@ -193,8 +193,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-welcome.task.gotoSiteC
       m_HashValue: 3153009468
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 3
       Target:
@@ -211,8 +209,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-welcome.task.scanGiantKelp
       m_HashValue: 1435432367
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -229,8 +225,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-welcome.task.scanUrchin
       m_HashValue: 2304311709
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -247,8 +241,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-welcome.task.scanOtter
       m_HashValue: 3579452656
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -265,8 +257,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-welcome.task.returnToShip
       m_HashValue: 728793182
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 3
       Target:
@@ -283,8 +273,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-welcome.task.runExperiment
       m_HashValue: 1674617243
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -307,8 +295,6 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-welcome.task.reportBack
       m_HashValue: 2154038550
-    TaskComplexity: 0
-    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Content/Jobs/KelpStationJobs/kelp-welcome/kelp-welcome.asset
+++ b/Assets/_Content/Jobs/KelpStationJobs/kelp-welcome/kelp-welcome.asset
@@ -50,6 +50,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-welcome.task.gotoSiteC
       m_HashValue: 3153009468
     Category: 1
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 3
       Target:
@@ -65,6 +67,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-welcome.task.scanGiantKelp
       m_HashValue: 1435432367
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -82,6 +86,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-welcome.task.scanUrchin
       m_HashValue: 2304311709
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -99,6 +105,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-welcome.task.scanOtter
       m_HashValue: 3579452656
     Category: 2
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -116,6 +124,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-welcome.task.returnToShip
       m_HashValue: 728793182
     Category: 1
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 3
       Target:
@@ -137,6 +147,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-welcome.task.runExperiment
       m_HashValue: 1674617243
     Category: 3
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 1
       Target:
@@ -160,6 +172,8 @@ MonoBehaviour:
       m_Source: jobs.kelp-welcome.task.reportBack
       m_HashValue: 2154038550
     Category: 5
+    TaskComplexity: 1
+    ScaffoldingComplexity: 1
     Steps:
     - Type: 10
       Target:
@@ -179,6 +193,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-welcome.task.gotoSiteC
       m_HashValue: 3153009468
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 3
       Target:
@@ -195,6 +211,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-welcome.task.scanGiantKelp
       m_HashValue: 1435432367
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -211,6 +229,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-welcome.task.scanUrchin
       m_HashValue: 2304311709
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -227,6 +247,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-welcome.task.scanOtter
       m_HashValue: 3579452656
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 0
       Target:
@@ -243,6 +265,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-welcome.task.returnToShip
       m_HashValue: 728793182
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 3
       Target:
@@ -259,6 +283,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-welcome.task.runExperiment
       m_HashValue: 1674617243
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 1
       Target:
@@ -281,6 +307,8 @@ MonoBehaviour:
     LabelId:
       m_Source: jobs.kelp-welcome.task.reportBack
       m_HashValue: 2154038550
+    TaskComplexity: 0
+    ScaffoldingComplexity: 0
     Steps:
     - Type: 10
       Target:

--- a/Assets/_Modules/Editor/DBExport.cs
+++ b/Assets/_Modules/Editor/DBExport.cs
@@ -37,6 +37,8 @@ namespace Aqua.Editor {
         private class JobData : ISerializedObject {
             public string Id;
             public ActiveRange Date;
+            public int topicComplexity;
+
             public MechanicRatingsData Difficulties;
             public int RequiredExp;
             public List<IdentifierData> RequiredJobs = new List<IdentifierData>();
@@ -48,6 +50,7 @@ namespace Aqua.Editor {
             public void Serialize(Serializer ioSerializer) {
                 ioSerializer.Serialize("id", ref Id);
                 ioSerializer.Object("date", ref Date);
+                ioSerializer.Serialize("topicComplexity", ref topicComplexity, 0);
                 ioSerializer.Serialize("requiredExp", ref RequiredExp, 0);
                 ioSerializer.ObjectArray("requiredJobs", ref RequiredJobs);
                 ioSerializer.ObjectArray("requiredUpgrades", ref RequiredUpgrades);
@@ -186,6 +189,7 @@ namespace Aqua.Editor {
                 }
 
                 jobData.RequiredExp = job.RequiredExp();
+                jobData.topicComplexity = job.TopicComplexity();
                 jobData.Difficulties.ExperimentationDifficulty = job.Difficulty(ScienceActivityType.Experimentation);
                 jobData.Difficulties.ModelingDifficulty = job.Difficulty(ScienceActivityType.Modeling);
                 jobData.Difficulties.ArgumentationDifficulty = job.Difficulty(ScienceActivityType.Argumentation);

--- a/Assets/_Modules/Editor/DBExport.cs
+++ b/Assets/_Modules/Editor/DBExport.cs
@@ -50,7 +50,7 @@ namespace Aqua.Editor {
             public void Serialize(Serializer ioSerializer) {
                 ioSerializer.Serialize("id", ref Id);
                 ioSerializer.Object("date", ref Date);
-                ioSerializer.Serialize("topicComplexity", ref topicComplexity, 0);
+                ioSerializer.Serialize("topicComplexity", ref topicComplexity);
                 ioSerializer.Serialize("requiredExp", ref RequiredExp, 0);
                 ioSerializer.ObjectArray("requiredJobs", ref RequiredJobs);
                 ioSerializer.ObjectArray("requiredUpgrades", ref RequiredUpgrades);
@@ -97,10 +97,14 @@ namespace Aqua.Editor {
 
         private class TaskData : IdentifierData {
             public JobDesc.JobTaskCategory Category;
+            public int TaskComplexity;
+            public int ScaffoldingComplexity;
 
             public override void Serialize(Serializer ioSerializer) {
                 base.Serialize(ioSerializer);
                 ioSerializer.Enum("category", ref Category, JobDesc.JobTaskCategory.Unknown, FieldOptions.Optional);
+                ioSerializer.Serialize("taskComplexity", ref TaskComplexity);
+                ioSerializer.Serialize("scaffoldingComplexity", ref ScaffoldingComplexity);
             }
         }
 
@@ -185,6 +189,8 @@ namespace Aqua.Editor {
                     }
 
                     taskData.Category = job.EditorTaskCategory(taskId);
+                    taskData.TaskComplexity = job.EditorTaskComplexity(taskId);
+                    taskData.ScaffoldingComplexity = job.EditorTaskScaffoldingComplexity(taskId);
                     taskData.Included = true;
                 }
 

--- a/Assets/_Modules/Editor/DBExport.cs
+++ b/Assets/_Modules/Editor/DBExport.cs
@@ -255,34 +255,34 @@ namespace Aqua.Editor {
                         Log.Warn("[DBExport] Job '{0}' required job '{1}' was deprecated but is now valid again? Please don't do that.", job.Id, reqJob.Id);
                         reqJob.Date.Deprecated = 0;
                     }
+                }
 
-                    foreach (var upgrade in job.RequiredUpgrades) {
-                        if (!upgrade.Included && upgrade.Date.Deprecated == 0) {
-                            Log.Msg("[DBExport] Job '{0}' required upgrade '{1}' found to be deprecated", job.Id, upgrade.Id);
-                            upgrade.Date.Deprecated = nowTS;
-                        } else if (upgrade.Included && upgrade.Date.Deprecated != 0) {
-                            Log.Warn("[DBExport] Job '{0}' required upgrade '{1}' was deprecated but is now valid again? Please don't do that.", job.Id, upgrade.Id);
-                            upgrade.Date.Deprecated = 0;
-                        }
+                foreach (var upgrade in job.RequiredUpgrades) {
+                    if (!upgrade.Included && upgrade.Date.Deprecated == 0) {
+                        Log.Msg("[DBExport] Job '{0}' required upgrade '{1}' found to be deprecated", job.Id, upgrade.Id);
+                        upgrade.Date.Deprecated = nowTS;
+                    } else if (upgrade.Included && upgrade.Date.Deprecated != 0) {
+                        Log.Warn("[DBExport] Job '{0}' required upgrade '{1}' was deprecated but is now valid again? Please don't do that.", job.Id, upgrade.Id);
+                        upgrade.Date.Deprecated = 0;
+                    }
+                }
+
+                foreach (var task in job.Tasks) {
+                    if (!task.Included && task.Date.Deprecated == 0) {
+                        Log.Msg("[DBExport] Job '{0}' task '{1}' found to be deprecated", job.Id, task.Id);
+                        task.Date.Deprecated = nowTS;
+                    } else if (task.Included && task.Date.Deprecated != 0) {
+                        Log.Warn("[DBExport] Job '{0}' task '{1}' was deprecated but is now valid again? Please don't do that.", job.Id, task.Id);
+                        task.Date.Deprecated = 0;
                     }
 
-                    foreach (var task in job.Tasks) {
-                        if (!task.Included && task.Date.Deprecated == 0) {
-                            Log.Msg("[DBExport] Job '{0}' task '{1}' found to be deprecated", job.Id, task.Id);
-                            task.Date.Deprecated = nowTS;
-                        } else if (task.Included && task.Date.Deprecated != 0) {
-                            Log.Warn("[DBExport] Job '{0}' task '{1}' was deprecated but is now valid again? Please don't do that.", job.Id, task.Id);
-                            task.Date.Deprecated = 0;
-                        }
-
-                        foreach (var reqTask in task.ReqTasks) {
-                            if (!reqTask.Included && reqTask.Date.Deprecated == 0) {
-                                Log.Msg("[DBExport] Task '{0}' required task '{1}' found to be deprecated", task.Id, reqTask.Id);
-                               reqTask.Date.Deprecated = nowTS; 
-                            } else if (reqTask.Included && reqTask.Date.Deprecated != 0) {
-                                Log.Warn("[DBExport] Task '{0}' required task '{1}' was deprecated but is now valid again? Please don't do that.", task.Id, reqTask.Id);
-                                reqTask.Date.Deprecated = 0;
-                            }
+                    foreach (var reqTask in task.ReqTasks) {
+                        if (!reqTask.Included && reqTask.Date.Deprecated == 0) {
+                            Log.Msg("[DBExport] Task '{0}' required task '{1}' found to be deprecated", task.Id, reqTask.Id);
+                            reqTask.Date.Deprecated = nowTS; 
+                        } else if (reqTask.Included && reqTask.Date.Deprecated != 0) {
+                            Log.Warn("[DBExport] Task '{0}' required task '{1}' was deprecated but is now valid again? Please don't do that.", task.Id, reqTask.Id);
+                            reqTask.Date.Deprecated = 0;
                         }
                     }
                 }

--- a/Assets/_Modules/Editor/DBExport.cs
+++ b/Assets/_Modules/Editor/DBExport.cs
@@ -37,7 +37,6 @@ namespace Aqua.Editor {
         private class JobData : ISerializedObject {
             public string Id;
             public ActiveRange Date;
-            public int topicComplexity;
 
             public MechanicRatingsData Difficulties;
             public int RequiredExp;
@@ -50,7 +49,6 @@ namespace Aqua.Editor {
             public void Serialize(Serializer ioSerializer) {
                 ioSerializer.Serialize("id", ref Id);
                 ioSerializer.Object("date", ref Date);
-                ioSerializer.Serialize("topicComplexity", ref topicComplexity);
                 ioSerializer.Serialize("requiredExp", ref RequiredExp, 0);
                 ioSerializer.ObjectArray("requiredJobs", ref RequiredJobs);
                 ioSerializer.ObjectArray("requiredUpgrades", ref RequiredUpgrades);
@@ -75,11 +73,14 @@ namespace Aqua.Editor {
             public int ExperimentationDifficulty;
             public int ModelingDifficulty;
             public int ArgumentationDifficulty;
+            public int TopicComplexity;
+
 
             public void Serialize(Serializer ioSerializer) {
                 ioSerializer.Serialize("experimentation", ref ExperimentationDifficulty);
                 ioSerializer.Serialize("modeling", ref ModelingDifficulty);
                 ioSerializer.Serialize("argumentation", ref ArgumentationDifficulty);
+                ioSerializer.Serialize("topicComplexity", ref TopicComplexity);
             }
         }
 
@@ -195,7 +196,7 @@ namespace Aqua.Editor {
                 }
 
                 jobData.RequiredExp = job.RequiredExp();
-                jobData.topicComplexity = job.TopicComplexity();
+                jobData.Difficulties.TopicComplexity = job.TopicComplexity();
                 jobData.Difficulties.ExperimentationDifficulty = job.Difficulty(ScienceActivityType.Experimentation);
                 jobData.Difficulties.ModelingDifficulty = job.Difficulty(ScienceActivityType.Modeling);
                 jobData.Difficulties.ArgumentationDifficulty = job.Difficulty(ScienceActivityType.Argumentation);

--- a/DBExport.json
+++ b/DBExport.json
@@ -30,7 +30,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportBack",
@@ -39,7 +41,27 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "findWhale",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "findTracker",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "foundDetritus",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "findTracker",
@@ -48,7 +70,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "foundDetritus",
@@ -57,7 +81,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "findWhale",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -109,7 +141,9 @@
                   "deprecated": 1.3294107995602E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportBack",
@@ -118,7 +152,9 @@
                },
                "category": "Argue",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 3
+               "scaffoldingComplexity": 3,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "getPops",
@@ -127,7 +163,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             }
          ]
       },
@@ -154,7 +192,9 @@
                   "added": 1.32914936623526E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "scanIceAlgae",
@@ -162,7 +202,9 @@
                   "added": 1.32914936623526E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportBack",
@@ -170,7 +212,9 @@
                   "added": 1.32914936623526E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             }
          ]
       },
@@ -197,7 +241,9 @@
                },
                "category": "Travel",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "getScans",
@@ -206,7 +252,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "visitSiteO",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "getCounts",
@@ -215,7 +269,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "getScans",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -224,7 +286,15 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "getCounts",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "makeModel",
@@ -232,7 +302,9 @@
                   "added": 1.3305916268445E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             }
          ]
       },
@@ -288,7 +360,9 @@
                   "deprecated": 1.3295916222049E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "jellyObservation",
@@ -297,7 +371,9 @@
                   "deprecated": 1.3295916222049E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "jellyRates",
@@ -306,7 +382,9 @@
                   "deprecated": 1.3295916222049E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "jellyPrediction",
@@ -315,7 +393,9 @@
                   "deprecated": 1.3295916222049E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportBack",
@@ -324,7 +404,9 @@
                   "deprecated": 1.3295916222049E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             }
          ]
       },
@@ -418,7 +500,9 @@
                   "deprecated": 1.33111006512628E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "measureOxygenUsage",
@@ -427,7 +511,9 @@
                   "deprecated": 1.33111006512628E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "createModel",
@@ -436,7 +522,9 @@
                   "deprecated": 1.33111006512628E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportBack",
@@ -445,7 +533,15 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "makeVisual",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "scanAll",
@@ -454,7 +550,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "measureCritters",
@@ -463,7 +561,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "scanAll",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "makeVisual",
@@ -472,7 +578,15 @@
                },
                "category": "Model",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "measureCritters",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -521,7 +635,9 @@
                   "deprecated": 1.3295916222049E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportBack",
@@ -530,7 +646,9 @@
                   "deprecated": 1.3295916222049E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             }
          ]
       },
@@ -565,7 +683,9 @@
                   "deprecated": 1.33111006512628E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportBack",
@@ -574,7 +694,9 @@
                   "deprecated": 1.33111006512628E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             }
          ]
       },
@@ -662,7 +784,9 @@
                   "deprecated": 1.33111006512628E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportBack",
@@ -671,7 +795,15 @@
                },
                "category": "Argue",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 3
+               "scaffoldingComplexity": 3,
+               "requiredTasks": [
+                  {
+                     "id": "createModel",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "createModel",
@@ -680,7 +812,9 @@
                },
                "category": "Model",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+               ]
             }
          ]
       },
@@ -725,7 +859,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "countCyano",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "visualModelO",
@@ -734,7 +876,15 @@
                },
                "category": "Model",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "experimentsForSiteO",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -743,7 +893,15 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "visualModelO",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "scanCyano",
@@ -752,7 +910,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "countCyano",
@@ -761,7 +921,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "scanCyano",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -842,7 +1010,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "syncModel",
@@ -851,7 +1021,15 @@
                },
                "category": "Model",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "measureStress",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -860,7 +1038,15 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "syncModel",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "measureStress",
@@ -869,7 +1055,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "historicalData",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -944,7 +1138,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "popProbe",
@@ -953,7 +1149,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "scanSarg",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "chemHistory",
@@ -962,7 +1166,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "scanSarg",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "sargGrowthRate",
@@ -971,7 +1183,21 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "chemHistory",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "popProbe",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "sargLight",
@@ -980,7 +1206,21 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "chemHistory",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "popProbe",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "coralGrowthRate",
@@ -989,7 +1229,21 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "chemHistory",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "popProbe",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "coralGrowthStressed",
@@ -998,7 +1252,21 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "chemHistory",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "popProbe",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "sargModel",
@@ -1007,7 +1275,39 @@
                },
                "category": "Model",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "coralGrowthStressed",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "sargLight",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "sargGrowthRate",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "coralGrowthRate",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "coralLight",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "sargArgue",
@@ -1016,7 +1316,15 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "sargModel",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "coralLight",
@@ -1025,7 +1333,21 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "chemHistory",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "popProbe",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -1058,7 +1380,9 @@
                },
                "category": "Experiment",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "urchinSargArgue",
@@ -1067,7 +1391,15 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "urchinSarg",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -1118,7 +1450,9 @@
                },
                "category": "Travel",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "scanProbes",
@@ -1127,7 +1461,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "countPopulation",
@@ -1136,7 +1472,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "argue",
@@ -1145,7 +1483,27 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "findReef",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "scanProbes",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "countPopulation",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -1196,7 +1554,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "historicalPopulations",
@@ -1205,7 +1565,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "getModel",
@@ -1214,7 +1576,21 @@
                },
                "category": "Model",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "getScans",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "historicalPopulations",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -1223,7 +1599,15 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "getModel",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -1311,7 +1695,9 @@
                   "deprecated": 1.3305916268445E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "scanCritters",
@@ -1320,7 +1706,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "scanHistory",
@@ -1329,7 +1717,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "countPopulation",
@@ -1338,7 +1728,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "observeEatRules",
@@ -1347,7 +1739,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "countPopulation",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "obtainStressRules",
@@ -1356,7 +1756,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "observeEatRules",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "measureStressEatRates",
@@ -1365,7 +1773,9 @@
                   "deprecated": 1.3305916268445E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "measureStressReproduceRates",
@@ -1374,7 +1784,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "measureEatRates",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "obtainChemistry",
@@ -1383,7 +1801,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "measureStressReproduceRates",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "predictModel",
@@ -1392,7 +1818,15 @@
                },
                "category": "Model",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "obtainChemistry",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "interveneModel",
@@ -1401,7 +1835,15 @@
                },
                "category": "Model",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "predictModel",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "argueIncentive",
@@ -1410,7 +1852,15 @@
                },
                "category": "Argue",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 3
+               "scaffoldingComplexity": 3,
+               "requiredTasks": [
+                  {
+                     "id": "interveneModel",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "measureEatRates",
@@ -1419,7 +1869,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "obtainStressRules",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -1458,7 +1916,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "observeInteractions",
@@ -1467,7 +1927,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "observeCoral",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "arguePredator",
@@ -1476,7 +1944,15 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "observeInteractions",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "observeCoral",
@@ -1485,7 +1961,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "scanNew",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -1536,7 +2020,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "observeEatAlgae",
@@ -1545,7 +2031,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "scanAll",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "measureEatRate",
@@ -1554,7 +2048,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "observeEatAlgae",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "modelPopulations",
@@ -1563,7 +2065,15 @@
                },
                "category": "Model",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "measureEatRate",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -1572,7 +2082,15 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "modelPopulations",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "histPop",
@@ -1581,7 +2099,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "scanAll",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -1632,7 +2158,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "whatTurtlesEat",
@@ -1641,7 +2169,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "scanReefEdge",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -1650,7 +2186,15 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "whatTurtlesEat",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "makeModel",
@@ -1658,7 +2202,9 @@
                   "added": 1.3305916268445E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             }
          ]
       },
@@ -1709,7 +2255,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "stressCoral",
@@ -1718,7 +2266,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "siteR",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -1727,7 +2283,15 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "stressCoral",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -1754,7 +2318,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "turtleModel",
@@ -1762,7 +2328,9 @@
                   "added": 1.32914936623526E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportBack",
@@ -1771,7 +2339,15 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "countTurtle",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "countTurtle",
@@ -1780,7 +2356,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "scanTurtle",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -1813,7 +2397,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "behavior",
@@ -1822,7 +2408,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "scanAll",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "turtleModel",
@@ -1831,7 +2425,15 @@
                },
                "category": "Model",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "behavior",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -1840,7 +2442,15 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "turtleModel",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -1875,7 +2485,9 @@
                   "deprecated": 1.33138730177673E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "urchinStressed",
@@ -1884,7 +2496,9 @@
                   "deprecated": 1.33138730177673E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "siteRModel",
@@ -1893,7 +2507,9 @@
                   "deprecated": 1.33138730177673E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "present",
@@ -1902,7 +2518,9 @@
                   "deprecated": 1.33138730177673E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             }
          ]
       },
@@ -1935,7 +2553,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "foodweb",
@@ -1944,7 +2564,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "siteA",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -1953,7 +2581,15 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "foodweb",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -1986,7 +2622,9 @@
                },
                "category": "Model",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportBack",
@@ -1995,7 +2633,15 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "foodweb",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -2052,7 +2698,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "waterData",
@@ -2061,7 +2709,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "stressParam",
@@ -2070,7 +2720,21 @@
                },
                "category": "Experiment",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "waterData",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "scanMussels",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "report",
@@ -2079,7 +2743,15 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "stressParam",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -2124,7 +2796,9 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "stressedRate",
@@ -2133,7 +2807,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "unstressedRate",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportChange",
@@ -2142,7 +2824,21 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "stressedRate",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "unstressedRate",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -2193,7 +2889,9 @@
                },
                "category": "Travel",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "histPop",
@@ -2202,7 +2900,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "visitSite",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "growthRates",
@@ -2211,7 +2917,21 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "histPop",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "histChem",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "growthRatesBull",
@@ -2220,7 +2940,21 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "histPop",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "histChem",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "lightRatesGiant",
@@ -2229,7 +2963,21 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "histPop",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "histChem",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "lightRatesBull",
@@ -2238,7 +2986,21 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "histPop",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "histChem",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "newModel",
@@ -2247,7 +3009,39 @@
                },
                "category": "Model",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "histPop",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "growthRates",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "growthRatesBull",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "lightRatesGiant",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "lightRatesBull",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "getPaid",
@@ -2256,7 +3050,15 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 3
+               "scaffoldingComplexity": 3,
+               "requiredTasks": [
+                  {
+                     "id": "newModel",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "histChem",
@@ -2265,7 +3067,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "visitSite",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -2304,7 +3114,9 @@
                },
                "category": "Model",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "shareModel",
@@ -2313,7 +3125,15 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "createModel",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -2352,7 +3172,9 @@
                },
                "category": "Model",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "return",
@@ -2361,7 +3183,15 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "makeAPlan",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -2412,7 +3242,9 @@
                },
                "category": "Experiment",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "getGiantKelpStress",
@@ -2421,7 +3253,9 @@
                },
                "category": "Experiment",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "argueSite",
@@ -2430,7 +3264,21 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "getBullKelpStress",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "getGiantKelpStress",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -2469,7 +3317,9 @@
                },
                "category": "Model",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportBack",
@@ -2478,7 +3328,15 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "predictSiteB",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -2529,7 +3387,9 @@
                },
                "category": "Travel",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "getProbeData",
@@ -2538,7 +3398,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "gotoSiteB",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "getTagged",
@@ -2547,7 +3415,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "gotoSiteB",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "visualSiteB",
@@ -2556,7 +3432,21 @@
                },
                "category": "Model",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "getProbeData",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "getTagged",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -2565,7 +3455,21 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "getProbeData",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "visualSiteB",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -2616,7 +3520,9 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "urchinEatGiant",
@@ -2625,7 +3531,9 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportBack",
@@ -2634,7 +3542,21 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "urchinEatBull",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "urchinEatGiant",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -2661,7 +3583,9 @@
                },
                "category": "Travel",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "scanGiantKelp",
@@ -2670,7 +3594,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "gotoSiteC",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "scanUrchin",
@@ -2679,7 +3611,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "gotoSiteC",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "scanOtter",
@@ -2688,7 +3628,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "gotoSiteC",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "returnToShip",
@@ -2697,7 +3645,27 @@
                },
                "category": "Travel",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "scanOtter",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "scanUrchin",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "scanGiantKelp",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "runExperiment",
@@ -2706,7 +3674,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "returnToShip",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -2715,7 +3691,15 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "runExperiment",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -2784,7 +3768,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "getPopulationData",
@@ -2793,7 +3779,9 @@
                   "deprecated": 1.3305916268445E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportBack",
@@ -2802,7 +3790,27 @@
                },
                "category": "Argue",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 3
+               "scaffoldingComplexity": 3,
+               "requiredTasks": [
+                  {
+                     "id": "getEnvironmentData",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "getHistPopulationData",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "getCurrPopulationData",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "getHistPopulationData",
@@ -2811,7 +3819,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "getCurrPopulationData",
@@ -2820,7 +3830,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             }
          ]
       },
@@ -2877,7 +3889,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "modelInteractions",
@@ -2886,7 +3900,15 @@
                },
                "category": "Model",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 3
+               "scaffoldingComplexity": 3,
+               "requiredTasks": [
+                  {
+                     "id": "scanCritters",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -2895,7 +3917,15 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "modelInteractions",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -2961,7 +3991,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "scanAll",
@@ -2970,7 +4002,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "experimentPredatorZ",
@@ -2979,7 +4013,9 @@
                   "deprecated": 1.3305916268445E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "findPredator",
@@ -2988,7 +4024,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "discussFindings",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "experimentPredatorAll",
@@ -2997,7 +4041,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "findPredator",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "countPopulations",
@@ -3006,7 +4058,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "experimentPredatorAll",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "determineStress",
@@ -3015,7 +4075,9 @@
                },
                "category": "Experiment",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "discussFindings",
@@ -3024,7 +4086,21 @@
                },
                "category": "Argue",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "checkPredator",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "determineStress",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "checkCrab",
@@ -3033,7 +4109,9 @@
                   "deprecated": 1.33067919669553E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "checkSeal",
@@ -3042,7 +4120,9 @@
                   "deprecated": 1.33067919669553E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "checkShark",
@@ -3051,7 +4131,9 @@
                   "deprecated": 1.33067919669553E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportFinal",
@@ -3060,7 +4142,21 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "countPopulations",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "determineStress",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "checkPredator",
@@ -3069,7 +4165,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "scanAll",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -3120,7 +4224,9 @@
                },
                "category": "Model",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "report",
@@ -3129,7 +4235,15 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "visualModel",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -3162,7 +4276,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportBack",
@@ -3171,7 +4287,15 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "explore",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -3204,7 +4328,9 @@
                   "deprecated": 1.3305916268445E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "getTagger",
@@ -3213,7 +4339,9 @@
                },
                "category": "Narrative",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "getVisualModel",
@@ -3222,7 +4350,9 @@
                },
                "category": "Narrative",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "returnShip",
@@ -3231,7 +4361,21 @@
                },
                "category": "Travel",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "getTagger",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "getVisualModel",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -3282,7 +4426,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "jellyObservation",
@@ -3291,7 +4437,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "jellyScan",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "jellyRates",
@@ -3300,7 +4454,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "jellyObservation",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "jellyPrediction",
@@ -3309,7 +4471,21 @@
                },
                "category": "Model",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "jellyObservation",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "jellyRates",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -3318,7 +4494,15 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "jellyPrediction",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -3363,7 +4547,9 @@
                },
                "category": "Model",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportBack",
@@ -3372,7 +4558,15 @@
                },
                "category": "Argue",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "interventionDecision",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -3412,7 +4606,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "countNew",
@@ -3421,7 +4617,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "scanNew",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "experimentInteractions",
@@ -3430,7 +4634,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "countNew",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "createModel",
@@ -3439,7 +4651,15 @@
                },
                "category": "Model",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "experimentInteractions",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -3448,7 +4668,15 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "createModel",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -3499,7 +4727,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "countAlgae",
@@ -3508,7 +4738,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "scanAlgae",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "observeEat",
@@ -3517,7 +4755,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "countAlgae",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -3526,7 +4772,15 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 3
+               "scaffoldingComplexity": 3,
+               "requiredTasks": [
+                  {
+                     "id": "observeEat",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -3571,7 +4825,9 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "obtainRateDiatoms",
@@ -3580,7 +4836,9 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportBack",
@@ -3589,7 +4847,21 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "obtainRateDiatoms",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "obtainRateAlgae",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -3652,7 +4924,9 @@
                },
                "category": "Experiment",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "modelFish",
@@ -3661,7 +4935,15 @@
                },
                "category": "Model",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "observeCod",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -3670,7 +4952,15 @@
                },
                "category": "Argue",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "modelFish",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -3709,7 +4999,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportBack",
@@ -3718,7 +5010,15 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "countSalmon",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -3763,7 +5063,9 @@
                   "added": 1.3305916268445E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "findHabitat",
@@ -3771,7 +5073,9 @@
                   "added": 1.3305916268445E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "findMicro",
@@ -3779,7 +5083,9 @@
                   "added": 1.3305916268445E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "findPop",
@@ -3787,7 +5093,9 @@
                   "added": 1.3305916268445E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "report",
@@ -3795,7 +5103,9 @@
                   "added": 1.3305916268445E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             }
          ]
       },
@@ -3846,7 +5156,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "wormEat",
@@ -3855,7 +5167,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "scanCritters",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "getModel",
@@ -3864,7 +5184,15 @@
                },
                "category": "Model",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "wormEat",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -3873,7 +5201,15 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "getModel",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -3912,7 +5248,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "methaneTag",
@@ -3921,7 +5259,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "methaneScan",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -3930,7 +5276,15 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "methaneTag",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -3981,7 +5335,9 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "StressRanges",
@@ -3990,7 +5346,9 @@
                },
                "category": "Experiment",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "WaterChem",
@@ -3999,7 +5357,9 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "Reproduction",
@@ -4009,7 +5369,9 @@
                },
                "category": "Experiment",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "Report",
@@ -4018,7 +5380,27 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "EatRule",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "StressRanges",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "WaterChem",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -4045,7 +5427,9 @@
                   "added": 1.3305916268445E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportBack",
@@ -4053,7 +5437,9 @@
                   "added": 1.3305916268445E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             }
          ]
       },
@@ -4104,7 +5490,9 @@
                },
                "category": "Experiment",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "findMicro",
@@ -4113,7 +5501,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "findStress",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "countIck",
@@ -4122,7 +5518,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "findMicro",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "observeIck",
@@ -4131,7 +5535,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "countIck",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reviseModels",
@@ -4140,7 +5552,15 @@
                },
                "category": "Model",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "observeIck",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "report",
@@ -4149,7 +5569,15 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "reviseModels",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -4194,7 +5622,9 @@
                },
                "category": "Travel",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "findRibbon",
@@ -4203,7 +5633,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "findMicro",
@@ -4212,7 +5644,21 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "findHabitat",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "findRibbon",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "countMicro",
@@ -4221,7 +5667,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "findMicro",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "findPop",
@@ -4229,7 +5683,9 @@
                   "added": 1.33067919669553E+17
                },
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "report",
@@ -4238,7 +5694,27 @@
                },
                "category": "Argue",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "countSeal",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "countMicro",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "findRibbon",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "countSeal",
@@ -4247,7 +5723,21 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "findHabitat",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "findRibbon",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -4322,7 +5812,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "modelSync",
@@ -4331,7 +5823,15 @@
                },
                "category": "Model",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "scanProbe",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "modelPredict",
@@ -4340,7 +5840,15 @@
                },
                "category": "Model",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "modelSync",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -4349,7 +5857,15 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "modelPredict",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -4412,7 +5928,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "countGreen",
@@ -4421,7 +5939,15 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "findGreen",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "stressCB",
@@ -4430,7 +5956,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "countGreen",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "measureEffect",
@@ -4439,7 +5973,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "stressCB",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "measureReproduce",
@@ -4448,7 +5990,15 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "stressCB",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -4457,7 +6007,21 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "measureReproduce",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "measureEffect",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -4502,7 +6066,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "countDetritus",
@@ -4511,7 +6077,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "eatDetritus",
@@ -4520,7 +6088,27 @@
                },
                "category": "Experiment",
                "taskComplexity": 1,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "countDetritus",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "scanNew",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "scanProbe",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "growDetritus",
@@ -4529,7 +6117,27 @@
                },
                "category": "Experiment",
                "taskComplexity": 3,
-               "scaffoldingComplexity": 2
+               "scaffoldingComplexity": 2,
+               "requiredTasks": [
+                  {
+                     "id": "countDetritus",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "scanNew",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "scanProbe",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -4538,7 +6146,21 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "eatDetritus",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  },
+                  {
+                     "id": "growDetritus",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "scanProbe",
@@ -4547,7 +6169,15 @@
                },
                "category": "Argue",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "scanNew",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -4586,7 +6216,9 @@
                },
                "category": "Scan_Count",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "reportBack",
@@ -4595,7 +6227,15 @@
                },
                "category": "Argue",
                "taskComplexity": 2,
-               "scaffoldingComplexity": 1
+               "scaffoldingComplexity": 1,
+               "requiredTasks": [
+                  {
+                     "id": "countShrimp",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       },
@@ -4622,7 +6262,9 @@
                },
                "category": "Narrative",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "createModel",
@@ -4631,7 +6273,15 @@
                },
                "category": "Model",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "tellMom",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "reportBack",
@@ -4640,7 +6290,15 @@
                },
                "category": "Argue",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "createModel",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "sneakOut",
@@ -4649,7 +6307,15 @@
                },
                "category": "Narrative",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "reportBack",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "getUncleHelp",
@@ -4658,7 +6324,15 @@
                },
                "category": "Narrative",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "sneakOut",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "checkShip",
@@ -4667,16 +6341,27 @@
                },
                "category": "Narrative",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "getUncleHelp",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             },
             {
                "id": "returnToShop",
                "date": {
-                  "added": 1.33138730177673E+17
+                  "added": 1.33138730177673E+17,
+                  "deprecated": 1.33312398136518E+17
                },
                "category": "Narrative",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+               ]
             },
             {
                "id": "performRescue",
@@ -4685,7 +6370,15 @@
                },
                "category": "Narrative",
                "taskComplexity": 0,
-               "scaffoldingComplexity": 0
+               "scaffoldingComplexity": 0,
+               "requiredTasks": [
+                  {
+                     "id": "checkShip",
+                     "date": {
+                        "added": 1.33312355881023E+17
+                     }
+                  }
+               ]
             }
          ]
       }

--- a/DBExport.json
+++ b/DBExport.json
@@ -32,6 +32,22 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Detritus",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "W_WhaleFall",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -61,6 +77,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -72,6 +90,15 @@
                "taskComplexity": 3,
                "scaffoldingComplexity": 2,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "WhaleTracker",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -87,6 +114,15 @@
                      "id": "findWhale",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "W_WhaleFall.Population.Detritus",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -143,6 +179,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -154,6 +192,8 @@
                "taskComplexity": 3,
                "scaffoldingComplexity": 3,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -165,6 +205,78 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "W_WhaleFall.Population.ArcticCod",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "W_WhaleFall.Population.BristleWorm",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "W_WhaleFall.Population.Detritus",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "W_WhaleFall.Population.Hagfish",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "W_WhaleFall.Population.IceAlgae",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "W_WhaleFall.Population.NorthAtlanticOctopus",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "W_WhaleFall.Population.SalmonShark",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "W_WhaleFall.Population.SnowCrab",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "W_WhaleFall.Population.ZombieWorm",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "W_WhaleFall.Population.ChinookSalmon",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             }
          ]
@@ -195,6 +307,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -206,6 +320,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -217,6 +333,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             }
          ]
@@ -246,6 +364,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -261,6 +381,43 @@
                      "id": "visitSiteO",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "LoggerheadTurtle",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "SeaPearl",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "AngelFish",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "RedGrouper",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "ElkhornCoral",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -280,6 +437,43 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "O_OilRig.Population.LoggerheadTurtle",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "O_OilRig.Population.AngelFish",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "O_OilRig.Population.RedGrouper",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "O_OilRig.Population.SeaPearl",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "O_OilRig.Population.ElkhornCoral",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -297,6 +491,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -308,6 +504,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             }
          ]
@@ -366,6 +564,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -377,6 +577,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -388,6 +590,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -399,6 +603,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -410,6 +616,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             }
          ]
@@ -506,6 +714,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -517,6 +727,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -528,6 +740,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -545,6 +759,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -556,6 +772,36 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Cyanobacteria",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "WhiteShrimp",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "DecomposingBacteria",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Detritus",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -573,6 +819,29 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Cyanobacteria.Produce.Oxygen",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "DecomposingBacteria.Consume.Oxygen",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "WhiteShrimp.Consume.Oxygen",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -588,6 +857,15 @@
                      "id": "measureCritters",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "P_DeadZone.Model.OxygenTracking.Visual",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -641,6 +919,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -652,6 +932,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             }
          ]
@@ -689,6 +971,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -700,6 +984,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             }
          ]
@@ -790,6 +1076,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -807,6 +1095,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -818,6 +1108,15 @@
                "taskComplexity": 2,
                "scaffoldingComplexity": 2,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "P_DeadZone.Model.Shrimptastrophe.Sync",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             }
          ]
@@ -871,6 +1170,22 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LoggerheadTurtle.Eats.AngelFish",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LoggerheadTurtle.Eats.Cyanobacteria",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -886,6 +1201,15 @@
                      "id": "experimentsForSiteO",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "O_OilRig.turtleDanger.Model.Visual",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -905,6 +1229,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -916,6 +1242,15 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Cyanobacteria",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -931,6 +1266,15 @@
                      "id": "scanCyano",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "O_OilRig.Population.Cyanobacteria",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -1016,6 +1360,15 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "O_OilRig.PopulationHistory.LoggerheadTurtle",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -1031,6 +1384,15 @@
                      "id": "measureStress",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "O_OilRig.turtleDanger.Model.Describe",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -1050,6 +1412,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -1065,6 +1429,43 @@
                      "id": "historicalData",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "AngelFish.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Cyanobacteria.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "ElkhornCoral.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "RedGrouper.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "SeaPearl.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -1144,6 +1545,15 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Sargassum",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -1161,6 +1571,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "SargassumCoveredReef.PopulationHistory.Sargassum",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -1176,6 +1595,22 @@
                      "id": "scanSarg",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "SargassumCoveredReef.Temperature.History",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "SargassumCoveredReef.WaterChemHistory.Light",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -1201,6 +1636,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "UpgradeFact",
+                     "id": "Sargassum.Reproduce",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -1222,6 +1666,15 @@
                      "id": "popProbe",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Sargassum.Consume.Light",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -1247,6 +1700,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "StaghornCoral.Reproduce",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -1268,6 +1730,15 @@
                      "id": "popProbe",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "StaghornCoral.Reproduce.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -1311,6 +1782,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "SargassumCoveredReef.Model.LightPrediction",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -1328,6 +1808,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -1349,6 +1831,15 @@
                      "id": "popProbe",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "StaghornCoral.Consume.Light",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -1386,6 +1877,15 @@
                "taskComplexity": 1,
                "scaffoldingComplexity": 1,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Urchin.Eats.Sargassum.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -1403,6 +1903,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -1456,6 +1958,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -1467,6 +1971,22 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.PopulationHistory.Lionfish",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.PopulationHistory.Fishers",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -1478,6 +1998,22 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.Population.StaghornCoral",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.Population.ArtificialReef",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -1507,6 +2043,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -1560,6 +2098,36 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Fishers",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "RedGrouper",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "ReefEdge.Population.Fishers",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Fishers.Eats.RedGrouper",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -1571,6 +2139,22 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "ReefEdge.PopulationHistory.RedGrouper",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "ReefEdge.PopulationHistory.Fishers",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -1594,6 +2178,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "ReefEdge.Model.GrouperFishingRate",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -1611,6 +2204,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -1701,6 +2296,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -1712,6 +2309,71 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "BlueheadWrasse",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "BlueTang",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Lionfish",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "RedGrouper",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Sargassum",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "StaghornCoral",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "TurfAlgae",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Ick",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Fishers",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -1723,6 +2385,22 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.Light.History",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.PopulationHistory.Lionfish",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -1734,6 +2412,50 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.Population.BlueheadWrasse",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.Population.BlueTang",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.Population.Lionfish",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.Population.StaghornCoral",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.Population.Sargassum",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.Population.Ick",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -1749,6 +2471,36 @@
                      "id": "countPopulation",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Lionfish.Eats.BlueheadWrasse",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Lionfish.Eats.BlueTang",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BlueTang.Eats.TurfAlgae",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BlueheadWrasse.Eats.Ick",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -1768,6 +2520,134 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BlueheadWrasse.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BlueheadWrasse.PH.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BlueheadWrasse.Temperature.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BlueTang.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BlueTang.PH.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BlueTang.Temperature.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Sargassum.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Sargassum.PH.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Sargassum.Temperature.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "StaghornCoral.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "StaghornCoral.PH.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "StaghornCoral.Temperature.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "TurfAlgae.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "TurfAlgae.PH.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "TurfAlgae.Temperature.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Lionfish.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Lionfish.Temperature.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "StaghornCoral.Reproduce.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -1779,6 +2659,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -1794,6 +2676,57 @@
                      "id": "measureEatRates",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "StaghornCoral.Reproduce",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BlueheadWrasse.Reproduce",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BlueTang.Reproduce",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Lionfish.Reproduce",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "TurfAlgae.Reproduce",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Sargassum.Reproduce",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Ick.Reproduce",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -1813,6 +2746,113 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Sargassum.Consume.CO2",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Sargassum.Produce.Oxygen",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Sargassum.Consume.Light",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "StaghornCoral.Consume.CO2",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "StaghornCoral.Produce.Oxygen",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "StaghornCoral.Consume.Light",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Lionfish.Consume.Oxygen",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Lionfish.Produce.CarbonDioxide",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BlueheadWrasse.Consume.Oxygen",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BlueheadWrasse.Produce.CarbonDioxide",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BlueTang.Consume.Oxygen",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BlueTang.Produce.CarbonDioxide",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "TurfAlgae.Consume.Light",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "TurfAlgae.Produce.Oxygen",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "TurfAlgae.Consume.CarbonDioxide",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -1828,6 +2868,15 @@
                      "id": "obtainChemistry",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.Model.HuntingLionsPrediction",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -1847,6 +2896,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.Model.HuntingLionsIntervene",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -1864,6 +2922,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -1879,6 +2939,36 @@
                      "id": "obtainStressRules",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "UpgradeFact",
+                     "id": "Lionfish.Eats.BlueheadWrasse",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "UpgradeFact",
+                     "id": "Lionfish.Eats.BlueTang",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "UpgradeFact",
+                     "id": "BlueTang.Eats.TurfAlgae",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "UpgradeFact",
+                     "id": "BlueheadWrasse.Eats.Ick",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -1922,6 +3012,29 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "BlueheadWrasse",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "BlueTang",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Lionfish",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -1937,6 +3050,22 @@
                      "id": "observeCoral",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Lionfish.Eats.BlueTang",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Lionfish.Eats.BlueheadWrasse",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -1956,6 +3085,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -1973,6 +3104,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -2026,6 +3159,57 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "RedGrouper",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Lionfish",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "StaghornCoral",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "BlueTang",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "BlueheadWrasse",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "TurfAlgae",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Sargassum",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -2041,6 +3225,15 @@
                      "id": "scanAll",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BlueTang.Eats.TurfAlgae",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -2060,6 +3253,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "UpgradeFact",
+                     "id": "BlueTang.Eats.TurfAlgae",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -2075,6 +3277,15 @@
                      "id": "measureEatRate",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.Model.MuchAlgaeDescriptive",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -2094,6 +3305,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -2109,6 +3322,29 @@
                      "id": "scanAll",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.PopulationHistory.Lionfish",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.PopulationHistory.StaghornCoral",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.PopulationHistory.Fishers",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -2164,6 +3400,43 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "LoggerheadTurtle",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Copepod",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "QueenConch",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "WhiteShrimp",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "StaghornCoral",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -2179,6 +3452,36 @@
                      "id": "scanReefEdge",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LoggerheadTurtle.Eats.QueenConch",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LoggerheadTurtle.Eats.WhiteShrimp",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LoggerheadTurtle.Eats.Copepod",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LoggerheadTurtle.Eats.PlasticBag",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -2198,6 +3501,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -2209,6 +3514,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             }
          ]
@@ -2262,6 +3569,22 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "StaghornCoral",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "SargassumCoveredReef",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -2277,6 +3600,15 @@
                      "id": "siteR",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "StaghornCoral.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -2296,6 +3628,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -2325,6 +3659,15 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "LoggerheadTurtle",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -2336,6 +3679,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -2353,6 +3698,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -2368,6 +3715,15 @@
                      "id": "scanTurtle",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "ReefEdge.Population.LoggerheadTurtle",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -2405,6 +3761,43 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "LoggerheadTurtle",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Copepod",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "QueenConch",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "WhiteShrimp",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "StaghornCoral",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -2420,6 +3813,29 @@
                      "id": "scanAll",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LoggerheadTurtle.Eats.QueenConch",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LoggerheadTurtle.Eats.WhiteShrimp",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LoggerheadTurtle.Eats.Copepod",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -2439,6 +3855,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "ReefEdge.Model.TurtleVisual",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -2456,6 +3881,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -2493,6 +3920,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -2504,6 +3933,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -2515,6 +3946,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -2526,6 +3959,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             }
          ]
@@ -2561,6 +3996,15 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "BullKelp",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -2576,6 +4020,15 @@
                      "id": "siteA",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Urchin.Eats.BullKelp",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -2595,6 +4048,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -2630,6 +4085,15 @@
                "taskComplexity": 1,
                "scaffoldingComplexity": 1,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "WarmKelpForest.Model.Conceptual",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -2647,6 +4111,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -2706,6 +4172,15 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Mussel",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -2717,6 +4192,29 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "WarmKelpForest.PH.History",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "WarmKelpForest.LightHistory",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "WarmKelpForest.Temperature.History",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -2740,6 +4238,29 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Mussel.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Mussel.PH.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Mussel.Temperature.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -2757,6 +4278,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -2804,6 +4327,15 @@
                "taskComplexity": 3,
                "scaffoldingComplexity": 2,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Mussel.Reproduce",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -2819,6 +4351,15 @@
                      "id": "unstressedRate",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Mussel.Reproduce.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -2844,6 +4385,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -2897,6 +4440,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -2912,6 +4457,22 @@
                      "id": "visitSite",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "MixedKelp.PopulationHistory.BullKelp",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "MixedKelp.PopulationHistory.GiantKelp",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -2937,6 +4498,22 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "GiantKelp.Reproduce",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "GiantKelp.Reproduce.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -2958,6 +4535,22 @@
                      "id": "histChem",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BullKelp.Reproduce",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BullKelp.Reproduce.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -2983,6 +4576,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "GiantKelp.Consume.Light",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -3004,6 +4606,15 @@
                      "id": "histChem",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BullKelp.Consume.Light",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -3047,6 +4658,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "MixedKelp.Model.RefugeFail",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -3064,6 +4684,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -3079,6 +4701,29 @@
                      "id": "visitSite",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "MixedKelp.PH.History",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "MixedKelp.Light.History",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "MixedKelp.Temperature.History",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -3122,6 +4767,15 @@
                "taskComplexity": 2,
                "scaffoldingComplexity": 2,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "MixedKelp.Model.RefugeFailPredict",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -3139,6 +4793,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -3180,6 +4836,15 @@
                "taskComplexity": 3,
                "scaffoldingComplexity": 1,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "UrchinBarren.Model.IntroduceOtters",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -3197,6 +4862,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -3250,6 +4917,22 @@
                "taskComplexity": 2,
                "scaffoldingComplexity": 1,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BullKelp.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BullKelp.Temperature.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -3261,6 +4944,22 @@
                "taskComplexity": 2,
                "scaffoldingComplexity": 1,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "GiantKelp.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "GiantKelp.Temperature.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -3284,6 +4983,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -3325,6 +5026,15 @@
                "taskComplexity": 2,
                "scaffoldingComplexity": 1,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "UrchinBarren.Model.Prediction",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -3342,6 +5052,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -3395,6 +5107,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -3412,6 +5126,22 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "UrchinBarren.PopulationHistory.Urchin",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "UrchinBarren.PopulationHistory.GiantKelp",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -3427,6 +5157,22 @@
                      "id": "gotoSiteB",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "UrchinBarren.Population.Urchin",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "UrchinBarren.Population.GiantKelp",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -3452,6 +5198,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "UrchinBarren.Model.Visual",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -3475,6 +5230,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -3528,6 +5285,15 @@
                "taskComplexity": 3,
                "scaffoldingComplexity": 1,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "UpgradeFact",
+                     "id": "Urchin.Eats.BullKelp",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -3539,6 +5305,15 @@
                "taskComplexity": 3,
                "scaffoldingComplexity": 1,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "UpgradeFact",
+                     "id": "Urchin.Eats.GiantKelp",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -3562,6 +5337,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -3591,6 +5368,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -3606,6 +5385,15 @@
                      "id": "gotoSiteC",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "GiantKelp",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -3625,6 +5413,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Urchin",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -3640,6 +5437,15 @@
                      "id": "gotoSiteC",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "SeaOtter",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -3671,6 +5477,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -3686,6 +5494,22 @@
                      "id": "returnToShip",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "SeaOtter.Eats.Urchin",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Urchin.Eats.GiantKelp",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -3705,6 +5529,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -3776,6 +5602,29 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "W_WhaleFall.PH.History",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "W_WhaleFall.Light.History",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "W_WhaleFall.Temperature.History",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -3787,6 +5636,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -3816,6 +5667,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -3827,6 +5680,22 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "W_WhaleFall.PopulationHistory.IceAlgae",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "W_WhaleFall.PopulationHistory.Diatoms",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -3838,6 +5707,22 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "W_WhaleFall.Population.IceAlgae",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "W_WhaleFall.Population.Diatoms",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             }
          ]
@@ -3897,6 +5782,57 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "W_WhaleFall",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "BristleWorm",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Hagfish",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "NorthAtlanticOctopus",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "SnowCrab",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "ZombieWorm",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Detritus",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -3912,6 +5848,15 @@
                      "id": "scanCritters",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "W_WhaleFall.Model.WhaleFallVisual",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -3931,6 +5876,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -3999,6 +5946,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -4010,6 +5959,64 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Diatoms",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Smelt",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "RibbonSeal",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "SalmonShark",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "ChinookSalmon",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "BowheadWhale",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "SnowCrab",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "SeaAnemone",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -4021,6 +6028,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -4036,6 +6045,15 @@
                      "id": "discussFindings",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "PterasterObscurus",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -4055,6 +6073,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "PterasterObscurus.Eats.GlassSponge",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -4072,6 +6099,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Y_IceCrevice.Population.PterasterObscurus",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -4083,6 +6119,29 @@
                "taskComplexity": 2,
                "scaffoldingComplexity": 2,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "GlassSponge.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "GlassSponge.PH.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "GlassSponge.Temperature.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -4106,6 +6165,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -4117,6 +6178,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -4128,6 +6191,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -4139,6 +6204,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -4162,6 +6229,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -4179,6 +6248,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -4232,6 +6303,15 @@
                "taskComplexity": 1,
                "scaffoldingComplexity": 2,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "X_UnderTheIce.Model.StationaryViz",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -4249,6 +6329,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -4285,6 +6367,29 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "X_UnderTheIce.Population.AstarteBorealis",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "X_UnderTheIce.Population.GlassSponge",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "X_UnderTheIce.Population.NorthernSeaNettle",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -4302,6 +6407,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -4337,6 +6444,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -4348,6 +6457,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -4359,6 +6470,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -4382,6 +6495,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -4435,6 +6550,15 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "MoonJelly",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -4452,6 +6576,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LoggerheadTurtle.Eats.MoonJelly",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -4467,6 +6600,15 @@
                      "id": "jellyObservation",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "UpgradeFact",
+                     "id": "LoggerheadTurtle.Eats.MoonJelly",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -4492,6 +6634,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "O_OilRig.turtleDangerJellies.Model.Predict",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -4509,6 +6660,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -4556,6 +6709,15 @@
                "taskComplexity": 3,
                "scaffoldingComplexity": 2,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "O_OilRig.turtleDangerNoReef.Model.Intervene",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -4573,6 +6735,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -4615,6 +6779,36 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "SnowCrab",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "AstarteBorealis",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "PterasterObscurus",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "ArcticCod",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -4630,6 +6824,36 @@
                      "id": "scanNew",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Y_IceCrevice.Population.SnowCrab",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Y_IceCrevice.Population.AstarteBorealis",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Y_IceCrevice.Population.PterasterObscurus",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Y_IceCrevice.Population.ArcticCod",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -4649,6 +6873,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "RibbonSeal.Eats.ArcticCod",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -4664,6 +6897,15 @@
                      "id": "experimentInteractions",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Y_IceCrevice.Model.AboveAndBelowVisual",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -4683,6 +6925,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -4736,6 +6980,15 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "IceAlgae",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -4751,6 +7004,15 @@
                      "id": "scanAlgae",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Z_OpenOcean.Population.IceAlgae",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -4770,6 +7032,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "ArcticCod.Eats.IceAlgae",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -4787,6 +7058,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -4834,6 +7107,15 @@
                "taskComplexity": 3,
                "scaffoldingComplexity": 2,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "UpgradeFact",
+                     "id": "ArcticCod.Eats.IceAlgae",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -4845,6 +7127,15 @@
                "taskComplexity": 3,
                "scaffoldingComplexity": 2,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "UpgradeFact",
+                     "id": "ArcticCod.Eats.Diatoms",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -4868,6 +7159,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -4933,6 +7226,22 @@
                "taskComplexity": 2,
                "scaffoldingComplexity": 2,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "ArcticCod.Eats.Diatoms",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "ArcticCod.Eats.IceAlgae",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -4948,6 +7257,15 @@
                      "id": "observeCod",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Z_OpenOcean.SalmonCompetition.Model.Sync",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -4967,6 +7285,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -5008,6 +7328,15 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Z_OpenOcean.Population.ChinookSalmon",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -5025,6 +7354,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -5076,6 +7407,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -5087,6 +7420,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -5098,6 +7433,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -5109,6 +7446,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -5120,6 +7459,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             }
          ]
@@ -5173,6 +7514,36 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Detritus",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "VentStar",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Methane",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "H_Gas",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -5188,6 +7559,50 @@
                      "id": "scanCritters",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Methanogen.Eats.H_Gas",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "VentStar.Eats.Detritus.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "DeepSeaSkate.Eats.VentStar.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BrooksiMussel.Eats.Methanogen.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "VentStar.Eats.BrooksiMussel.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Tubeworm.Eats.Methanogen",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -5207,6 +7622,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "N_ThermalVent.Model.Visual",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -5224,6 +7648,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -5265,6 +7691,15 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Methane",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -5280,6 +7715,15 @@
                      "id": "methaneScan",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "N_ThermalVent.Population.Methane",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -5299,6 +7743,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -5352,6 +7798,22 @@
                "taskComplexity": 3,
                "scaffoldingComplexity": 2,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Methanogen.Eats.H_Gas",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "UpgradeFact",
+                     "id": "Methanogen.Eats.H_Gas",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -5363,6 +7825,29 @@
                "taskComplexity": 2,
                "scaffoldingComplexity": 2,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Methanogen.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Methanogen.PH.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Methanogen.Temperature.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -5374,6 +7859,22 @@
                "taskComplexity": 3,
                "scaffoldingComplexity": 2,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Methanogen.Consume.CarbonDioxide",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Methanogen.Consume.CarbonDioxide.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -5386,6 +7887,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -5415,6 +7918,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -5445,6 +7950,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -5456,6 +7963,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             }
          ]
@@ -5509,6 +8018,29 @@
                "taskComplexity": 2,
                "scaffoldingComplexity": 2,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BlueTang.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BlueTang.PH.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "BlueTang.Temperature.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -5524,6 +8056,15 @@
                      "id": "findStress",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Ick",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -5543,6 +8084,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.Population.Ick",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -5558,6 +8108,15 @@
                      "id": "countIck",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Ick.Stresses.BlueTang",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -5577,6 +8136,22 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.Model.IckStressVisual",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "LionfishInvasion.Model.IckStressDescribe",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -5594,6 +8169,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -5641,6 +8218,15 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Y_IceCrevice",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -5652,6 +8238,15 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "RibbonSeal",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -5675,6 +8270,36 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "ArcticCopepod",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "GlacialAmphipod",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Clione",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "IceAlgae",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -5692,6 +8317,36 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Y_IceCrevice.Population.ArcticCopepod",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Y_IceCrevice.Population.GlacialAmphipod",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Y_IceCrevice.Population.Clione",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Y_IceCrevice.Population.IceAlgae",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -5703,6 +8358,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -5732,6 +8389,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -5753,6 +8412,15 @@
                      "id": "findRibbon",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Y_IceCrevice.Population.RibbonSeal",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -5832,6 +8500,15 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Y_IceCrevice.PopulationHistory.IceAlgae",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -5847,6 +8524,15 @@
                      "id": "scanProbe",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Y_IceCrevice.Model.EndangeredSealsDescribe",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -5866,6 +8552,15 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Y_IceCrevice.Model.EndangeredSealsPredict",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -5883,6 +8578,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -5948,6 +8645,15 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Cyanobacteria",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -5963,6 +8669,15 @@
                      "id": "findGreen",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "P_DeadZone.Population.Cyanobacteria",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -5982,6 +8697,29 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Cyanobacteria.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Cyanobacteria.PH.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Cyanobacteria.Temperature.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -5999,6 +8737,22 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Cyanobacteria.Consume.Light",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Cyanobacteria.Consume.Light.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -6014,6 +8768,22 @@
                      "id": "stressCB",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Cyanobacteria.Reproduce",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "Cyanobacteria.Reproduce.Stressed",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -6039,6 +8809,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -6086,6 +8858,36 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Cyanobacteria",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "Detritus",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "WhiteShrimp",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "DecomposingBacteria",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -6097,6 +8899,15 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "P_DeadZone.Population.Detritus",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -6124,6 +8935,15 @@
                      "id": "scanProbe",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "DecomposingBacteria.Eats.Detritus",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -6155,6 +8975,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -6178,6 +9000,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -6193,6 +9017,15 @@
                      "id": "scanNew",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "P_DeadZone.PopulationHistory.Detritus",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -6236,6 +9069,22 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireBestiaryEntry",
+                     "id": "WhiteShrimp",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  },
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "P_DeadZone.Population.WhiteShrimp",
+                     "date": {
+                        "added": 1.33313401215275E+17
+                     }
+                  }
                ]
             },
             {
@@ -6253,6 +9102,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]
@@ -6282,6 +9133,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -6297,6 +9150,15 @@
                      "id": "tellMom",
                      "date": {
                         "added": 1.33312355881023E+17
+                     }
+                  }
+               ],
+               "steps": [
+                  {
+                     "stepType": "AcquireFact",
+                     "id": "DeepDeepSea.Model.Visual",
+                     "date": {
+                        "added": 1.33313401215275E+17
                      }
                   }
                ]
@@ -6316,6 +9178,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -6333,6 +9197,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -6350,6 +9216,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -6367,6 +9235,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             },
             {
@@ -6379,6 +9249,8 @@
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
                "requiredTasks": [
+               ],
+               "steps": [
                ]
             },
             {
@@ -6396,6 +9268,8 @@
                         "added": 1.33312355881023E+17
                      }
                   }
+               ],
+               "steps": [
                ]
             }
          ]

--- a/DBExport.json
+++ b/DBExport.json
@@ -28,28 +28,36 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "findTracker",
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "foundDetritus",
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       },
@@ -99,21 +107,27 @@
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.3294107995602E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 3
             },
             {
                "id": "getPops",
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       },
@@ -123,6 +137,7 @@
             "added": 1.32914936623526E+17,
             "deprecated": 1.33138730177673E+17
          },
+         "topicComplexity": 0,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -137,19 +152,25 @@
                "id": "scanAndTag",
                "date": {
                   "added": 1.32914936623526E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "scanIceAlgae",
                "date": {
                   "added": 1.32914936623526E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       },
@@ -174,34 +195,44 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Travel"
+               "category": "Travel",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "getScans",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "getCounts",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "makeModel",
                "date": {
                   "added": 1.3305916268445E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       },
@@ -211,6 +242,7 @@
             "added": 1.32914936623526E+17,
             "deprecated": 1.3295916222049E+17
          },
+         "topicComplexity": 0,
          "requiredJobs": [
             {
                "id": "turtle-danger2",
@@ -254,35 +286,45 @@
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.3295916222049E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "jellyObservation",
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.3295916222049E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "jellyRates",
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.3295916222049E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "jellyPrediction",
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.3295916222049E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.3295916222049E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       },
@@ -374,49 +416,63 @@
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.33111006512628E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "measureOxygenUsage",
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.33111006512628E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "createModel",
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.33111006512628E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "scanAll",
                "date": {
                   "added": 1.33111006512628E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "measureCritters",
                "date": {
                   "added": 1.33111006512628E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "makeVisual",
                "date": {
                   "added": 1.33111006512628E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             }
          ]
       },
@@ -426,6 +482,7 @@
             "added": 1.32914936623526E+17,
             "deprecated": 1.3295916222049E+17
          },
+         "topicComplexity": 0,
          "requiredJobs": [
             {
                "id": "turtle-danger2",
@@ -462,14 +519,18 @@
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.3295916222049E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.3295916222049E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       },
@@ -479,6 +540,7 @@
             "added": 1.32914936623526E+17,
             "deprecated": 1.33111006512628E+17
          },
+         "topicComplexity": 0,
          "requiredJobs": [
             {
                "id": "bayou-save-our-shrimp",
@@ -501,14 +563,18 @@
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.33111006512628E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.33111006512628E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       },
@@ -594,21 +660,27 @@
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.33111006512628E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 3
             },
             {
                "id": "createModel",
                "date": {
                   "added": 1.33111006512628E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             }
          ]
       },
@@ -651,35 +723,45 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "visualModelO",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "scanCyano",
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "countCyano",
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       },
@@ -758,28 +840,36 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "syncModel",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "measureStress",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             }
          ]
       },
@@ -852,70 +942,90 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "popProbe",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "chemHistory",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "sargGrowthRate",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "sargLight",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "coralGrowthRate",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "coralGrowthStressed",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "sargModel",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "sargArgue",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "coralLight",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             }
          ]
       },
@@ -924,6 +1034,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 0,
          "requiredJobs": [
             {
                "id": "coral-casting-shade",
@@ -945,14 +1056,18 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "urchinSargArgue",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -1001,28 +1116,36 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Travel"
+               "category": "Travel",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "scanProbes",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "countPopulation",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "argue",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             }
          ]
       },
@@ -1071,28 +1194,36 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "historicalPopulations",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "getModel",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -1178,91 +1309,117 @@
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.3305916268445E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "scanCritters",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "scanHistory",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "countPopulation",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "observeEatRules",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "obtainStressRules",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "measureStressEatRates",
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.3305916268445E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "measureStressReproduceRates",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "obtainChemistry",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "predictModel",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "interveneModel",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "argueIncentive",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 3
             },
             {
                "id": "measureEatRates",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             }
          ]
       },
@@ -1299,28 +1456,36 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "observeInteractions",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "arguePredator",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "observeCoral",
                "date": {
                   "added": 1.33080912981555E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             }
          ]
       },
@@ -1369,42 +1534,54 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "observeEatAlgae",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "measureEatRate",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "modelPopulations",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "histPop",
                "date": {
                   "added": 1.32953898419312E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       },
@@ -1453,27 +1630,35 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "whatTurtlesEat",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "makeModel",
                "date": {
                   "added": 1.3305916268445E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       },
@@ -1522,21 +1707,27 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "stressCoral",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             }
          ]
       },
@@ -1545,6 +1736,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 0,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -1560,27 +1752,35 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "turtleModel",
                "date": {
                   "added": 1.32914936623526E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "countTurtle",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       },
@@ -1611,28 +1811,36 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "behavior",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "turtleModel",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -1642,6 +1850,7 @@
             "added": 1.32914936623526E+17,
             "deprecated": 1.33138730177673E+17
          },
+         "topicComplexity": 0,
          "requiredJobs": [
             {
                "id": "coral-urchin-friends",
@@ -1664,28 +1873,36 @@
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.33138730177673E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "urchinStressed",
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.33138730177673E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "siteRModel",
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.33138730177673E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "present",
                "date": {
                   "added": 1.32914936623526E+17,
                   "deprecated": 1.33138730177673E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       },
@@ -1716,21 +1933,27 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "foodweb",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -1761,14 +1984,18 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -1823,28 +2050,36 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "waterData",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "stressParam",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "report",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -1887,21 +2122,27 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "stressedRate",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "reportChange",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             }
          ]
       },
@@ -1950,63 +2191,81 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Travel"
+               "category": "Travel",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "histPop",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "growthRates",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "growthRatesBull",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "lightRatesGiant",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "lightRatesBull",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "newModel",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "getPaid",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 3
             },
             {
                "id": "histChem",
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       },
@@ -2043,14 +2302,18 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "shareModel",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -2087,14 +2350,18 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "return",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -2143,21 +2410,27 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "getGiantKelpStress",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "argueSite",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -2194,14 +2467,18 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -2250,35 +2527,45 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Travel"
+               "category": "Travel",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "getProbeData",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "getTagged",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "visualSiteB",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -2327,21 +2614,27 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "urchinEatGiant",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -2366,49 +2659,63 @@
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Travel"
+               "category": "Travel",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "scanGiantKelp",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "scanUrchin",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "scanOtter",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "returnToShip",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Travel"
+               "category": "Travel",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "runExperiment",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.32914936623526E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -2475,35 +2782,45 @@
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "getPopulationData",
                "date": {
                   "added": 1.3294107995602E+17,
                   "deprecated": 1.3305916268445E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 3
             },
             {
                "id": "getHistPopulationData",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "getCurrPopulationData",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       },
@@ -2558,21 +2875,27 @@
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "modelInteractions",
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 3
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -2636,91 +2959,117 @@
                   "added": 1.3294107995602E+17,
                   "deprecated": 1.33311514440551E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "scanAll",
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "experimentPredatorZ",
                "date": {
                   "added": 1.3294107995602E+17,
                   "deprecated": 1.3305916268445E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "findPredator",
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "experimentPredatorAll",
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "countPopulations",
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "determineStress",
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "discussFindings",
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "checkCrab",
                "date": {
                   "added": 1.3305916268445E+17,
                   "deprecated": 1.33067919669553E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "checkSeal",
                "date": {
                   "added": 1.3305916268445E+17,
                   "deprecated": 1.33067919669553E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "checkShark",
                "date": {
                   "added": 1.3305916268445E+17,
                   "deprecated": 1.33067919669553E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "reportFinal",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "checkPredator",
                "date": {
                   "added": 1.33067919669553E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             }
          ]
       },
@@ -2769,14 +3118,18 @@
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "report",
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             }
          ]
       },
@@ -2807,14 +3160,18 @@
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.3294107995602E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -2823,6 +3180,7 @@
          "date": {
             "added": 1.32953898419312E+17
          },
+         "topicComplexity": 0,
          "requiredJobs": [
             {
                "id": "kelp-bull-kelp-forest",
@@ -2844,28 +3202,36 @@
                "date": {
                   "added": 1.32953898419312E+17,
                   "deprecated": 1.3305916268445E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "getTagger",
                "date": {
                   "added": 1.32953898419312E+17
                },
-               "category": "Narrative"
+               "category": "Narrative",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "getVisualModel",
                "date": {
                   "added": 1.32953898419312E+17
                },
-               "category": "Narrative"
+               "category": "Narrative",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "returnShip",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Travel"
+               "category": "Travel",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       },
@@ -2914,35 +3280,45 @@
                "date": {
                   "added": 1.3295916222049E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "jellyObservation",
                "date": {
                   "added": 1.3295916222049E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "jellyRates",
                "date": {
                   "added": 1.3295916222049E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "jellyPrediction",
                "date": {
                   "added": 1.3295916222049E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.3295916222049E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -2985,14 +3361,18 @@
                "date": {
                   "added": 1.3295916222049E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.3295916222049E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             }
          ]
       },
@@ -3030,35 +3410,45 @@
                "date": {
                   "added": 1.33080912981555E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "countNew",
                "date": {
                   "added": 1.33080912981555E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "experimentInteractions",
                "date": {
                   "added": 1.33080912981555E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "createModel",
                "date": {
                   "added": 1.33080912981555E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.33080912981555E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             }
          ]
       },
@@ -3107,28 +3497,36 @@
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "countAlgae",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "observeEat",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 3
             }
          ]
       },
@@ -3171,21 +3569,27 @@
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "obtainRateDiatoms",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             }
          ]
       },
@@ -3246,21 +3650,27 @@
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "modelFish",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             }
          ]
       },
@@ -3269,6 +3679,7 @@
          "date": {
             "added": 1.3305916268445E+17
          },
+         "topicComplexity": 0,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -3296,14 +3707,18 @@
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -3313,6 +3728,7 @@
             "added": 1.3305916268445E+17,
             "deprecated": 1.33080912981555E+17
          },
+         "topicComplexity": 0,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -3345,31 +3761,41 @@
                "id": "findRibbon",
                "date": {
                   "added": 1.3305916268445E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "findHabitat",
                "date": {
                   "added": 1.3305916268445E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "findMicro",
                "date": {
                   "added": 1.3305916268445E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "findPop",
                "date": {
                   "added": 1.3305916268445E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "report",
                "date": {
                   "added": 1.3305916268445E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       },
@@ -3418,28 +3844,36 @@
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "wormEat",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "getModel",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -3476,21 +3910,27 @@
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "methaneTag",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -3539,21 +3979,27 @@
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "StressRanges",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "WaterChem",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "Reproduction",
@@ -3561,14 +4007,18 @@
                   "added": 1.3305916268445E+17,
                   "deprecated": 1.33311514440551E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "Report",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             }
          ]
       },
@@ -3578,6 +4028,7 @@
             "added": 1.3305916268445E+17,
             "deprecated": 1.33138730940424E+17
          },
+         "topicComplexity": 0,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -3592,13 +4043,17 @@
                "id": "obtainSyncModel",
                "date": {
                   "added": 1.3305916268445E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.3305916268445E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       },
@@ -3647,42 +4102,54 @@
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "findMicro",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "countIck",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "observeIck",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "reviseModels",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "report",
                "date": {
                   "added": 1.3305916268445E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -3725,48 +4192,62 @@
                "date": {
                   "added": 1.33067919669553E+17
                },
-               "category": "Travel"
+               "category": "Travel",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "findRibbon",
                "date": {
                   "added": 1.33067919669553E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "findMicro",
                "date": {
                   "added": 1.33067919669553E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "countMicro",
                "date": {
                   "added": 1.33067919669553E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "findPop",
                "date": {
                   "added": 1.33067919669553E+17
-               }
+               },
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "report",
                "date": {
                   "added": 1.33067919669553E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "countSeal",
                "date": {
                   "added": 1.33080912981555E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       },
@@ -3839,28 +4320,36 @@
                "date": {
                   "added": 1.33080912981555E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "modelSync",
                "date": {
                   "added": 1.33080912981555E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "modelPredict",
                "date": {
                   "added": 1.33080912981555E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.33080912981555E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -3921,42 +4410,54 @@
                "date": {
                   "added": 1.33111006512628E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "countGreen",
                "date": {
                   "added": 1.33111006512628E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "stressCB",
                "date": {
                   "added": 1.33111006512628E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "measureEffect",
                "date": {
                   "added": 1.33111006512628E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "measureReproduce",
                "date": {
                   "added": 1.33111006512628E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.33111006512628E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -3999,42 +4500,54 @@
                "date": {
                   "added": 1.33111006512628E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "countDetritus",
                "date": {
                   "added": 1.33111006512628E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "eatDetritus",
                "date": {
                   "added": 1.33111006512628E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 1,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "growDetritus",
                "date": {
                   "added": 1.33111006512628E+17
                },
-               "category": "Experiment"
+               "category": "Experiment",
+               "taskComplexity": 3,
+               "scaffoldingComplexity": 2
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.33111006512628E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             },
             {
                "id": "scanProbe",
                "date": {
                   "added": 1.33311514440551E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       },
@@ -4043,6 +4556,7 @@
          "date": {
             "added": 1.33111006512628E+17
          },
+         "topicComplexity": 0,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -4070,14 +4584,18 @@
                "date": {
                   "added": 1.33111006512628E+17
                },
-               "category": "Scan_Count"
+               "category": "Scan_Count",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.33111006512628E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 2,
+               "scaffoldingComplexity": 1
             }
          ]
       },
@@ -4086,6 +4604,7 @@
          "date": {
             "added": 1.33138730177673E+17
          },
+         "topicComplexity": 0,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -4101,56 +4620,72 @@
                "date": {
                   "added": 1.33138730177673E+17
                },
-               "category": "Narrative"
+               "category": "Narrative",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "createModel",
                "date": {
                   "added": 1.33138730177673E+17
                },
-               "category": "Model"
+               "category": "Model",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "reportBack",
                "date": {
                   "added": 1.33138730177673E+17
                },
-               "category": "Argue"
+               "category": "Argue",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "sneakOut",
                "date": {
                   "added": 1.33138730177673E+17
                },
-               "category": "Narrative"
+               "category": "Narrative",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "getUncleHelp",
                "date": {
                   "added": 1.33138730177673E+17
                },
-               "category": "Narrative"
+               "category": "Narrative",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "checkShip",
                "date": {
                   "added": 1.33138730177673E+17
                },
-               "category": "Narrative"
+               "category": "Narrative",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "returnToShop",
                "date": {
                   "added": 1.33138730177673E+17
                },
-               "category": "Narrative"
+               "category": "Narrative",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             },
             {
                "id": "performRescue",
                "date": {
                   "added": 1.33174634552926E+17
                },
-               "category": "Narrative"
+               "category": "Narrative",
+               "taskComplexity": 0,
+               "scaffoldingComplexity": 0
             }
          ]
       }

--- a/DBExport.json
+++ b/DBExport.json
@@ -189,7 +189,8 @@
             {
                "id": "scanAndTag",
                "date": {
-                  "added": 1.32914936623526E+17
+                  "added": 1.32914936623526E+17,
+                  "deprecated": 1.33313284421198E+17
                },
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
@@ -199,7 +200,8 @@
             {
                "id": "scanIceAlgae",
                "date": {
-                  "added": 1.32914936623526E+17
+                  "added": 1.32914936623526E+17,
+                  "deprecated": 1.33313284421198E+17
                },
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
@@ -209,7 +211,8 @@
             {
                "id": "reportBack",
                "date": {
-                  "added": 1.32914936623526E+17
+                  "added": 1.32914936623526E+17,
+                  "deprecated": 1.33313284421198E+17
                },
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
@@ -299,7 +302,8 @@
             {
                "id": "makeModel",
                "date": {
-                  "added": 1.3305916268445E+17
+                  "added": 1.3305916268445E+17,
+                  "deprecated": 1.33313284421198E+17
                },
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
@@ -2199,7 +2203,8 @@
             {
                "id": "makeModel",
                "date": {
-                  "added": 1.3305916268445E+17
+                  "added": 1.3305916268445E+17,
+                  "deprecated": 1.33313284421198E+17
                },
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
@@ -2325,7 +2330,8 @@
             {
                "id": "turtleModel",
                "date": {
-                  "added": 1.32914936623526E+17
+                  "added": 1.32914936623526E+17,
+                  "deprecated": 1.33313284421198E+17
                },
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
@@ -4258,7 +4264,8 @@
             {
                "id": "Flashlight",
                "date": {
-                  "added": 1.32953898419312E+17
+                  "added": 1.32953898419312E+17,
+                  "deprecated": 1.33313284421198E+17
                }
             }
          ],
@@ -5034,19 +5041,22 @@
             {
                "id": "ROVTagger",
                "date": {
-                  "added": 1.3305916268445E+17
+                  "added": 1.3305916268445E+17,
+                  "deprecated": 1.33313284421198E+17
                }
             },
             {
                "id": "Icebreaker",
                "date": {
-                  "added": 1.3305916268445E+17
+                  "added": 1.3305916268445E+17,
+                  "deprecated": 1.33313284421198E+17
                }
             },
             {
                "id": "Microscope",
                "date": {
-                  "added": 1.3305916268445E+17
+                  "added": 1.3305916268445E+17,
+                  "deprecated": 1.33313284421198E+17
                }
             }
          ],
@@ -5060,7 +5070,8 @@
             {
                "id": "findRibbon",
                "date": {
-                  "added": 1.3305916268445E+17
+                  "added": 1.3305916268445E+17,
+                  "deprecated": 1.33313284421198E+17
                },
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
@@ -5070,7 +5081,8 @@
             {
                "id": "findHabitat",
                "date": {
-                  "added": 1.3305916268445E+17
+                  "added": 1.3305916268445E+17,
+                  "deprecated": 1.33313284421198E+17
                },
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
@@ -5080,7 +5092,8 @@
             {
                "id": "findMicro",
                "date": {
-                  "added": 1.3305916268445E+17
+                  "added": 1.3305916268445E+17,
+                  "deprecated": 1.33313284421198E+17
                },
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
@@ -5090,7 +5103,8 @@
             {
                "id": "findPop",
                "date": {
-                  "added": 1.3305916268445E+17
+                  "added": 1.3305916268445E+17,
+                  "deprecated": 1.33313284421198E+17
                },
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
@@ -5100,7 +5114,8 @@
             {
                "id": "report",
                "date": {
-                  "added": 1.3305916268445E+17
+                  "added": 1.3305916268445E+17,
+                  "deprecated": 1.33313284421198E+17
                },
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
@@ -5424,7 +5439,8 @@
             {
                "id": "obtainSyncModel",
                "date": {
-                  "added": 1.3305916268445E+17
+                  "added": 1.3305916268445E+17,
+                  "deprecated": 1.33313284421198E+17
                },
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
@@ -5434,7 +5450,8 @@
             {
                "id": "reportBack",
                "date": {
-                  "added": 1.3305916268445E+17
+                  "added": 1.3305916268445E+17,
+                  "deprecated": 1.33313284421198E+17
                },
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,
@@ -5680,7 +5697,8 @@
             {
                "id": "findPop",
                "date": {
-                  "added": 1.33067919669553E+17
+                  "added": 1.33067919669553E+17,
+                  "deprecated": 1.33313284421198E+17
                },
                "taskComplexity": 0,
                "scaffoldingComplexity": 0,

--- a/DBExport.json
+++ b/DBExport.json
@@ -6,6 +6,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 1,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -57,6 +58,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "arctic-disappearing-act",
@@ -156,6 +158,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 1,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -288,6 +291,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "bayou-shrimp-tastrophe",
@@ -513,6 +517,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "bayou-save-our-shrimp",
@@ -570,6 +575,12 @@
                "date": {
                   "added": 1.33111006512628E+17
                }
+            },
+            {
+               "id": "ProbeHacker",
+               "date": {
+                  "added": 1.33311514440551E+17
+               }
             }
          ],
          "difficulties": {
@@ -606,6 +617,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "displaced-reef",
@@ -676,6 +688,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "turtle-danger",
@@ -775,6 +788,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "coral-stressed",
@@ -947,6 +961,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "coral-turtle-population",
@@ -1016,6 +1031,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -1085,6 +1101,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "coral-lionfish-conspiracy",
@@ -1254,6 +1271,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 1,
          "requiredJobs": [
             {
                "id": "coral-fake-fix",
@@ -1311,6 +1329,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "coral-fake-fix",
@@ -1394,6 +1413,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 1,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -1462,6 +1482,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -1568,6 +1589,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 1,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -1672,6 +1694,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 1,
          "requiredJobs": [
             {
                "id": "kelp-welcome",
@@ -1716,6 +1739,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 1,
          "requiredJobs": [
             {
                "id": "kelp-shop-welcome",
@@ -1753,6 +1777,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "kelp-welcome",
@@ -1828,6 +1853,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "kelp-mussel-fest",
@@ -1884,6 +1910,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "kelp-start-refuge",
@@ -1988,6 +2015,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "kelp-refuge-failure",
@@ -2031,6 +2059,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "kelp-urchin-barren-predict",
@@ -2074,6 +2103,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "kelp-welcome",
@@ -2136,6 +2166,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 1,
          "requiredJobs": [
             {
                "id": "kelp-urchin-barren-viz",
@@ -2179,6 +2210,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 1,
          "requiredJobs": [
             {
                "id": "kelp-welcome",
@@ -2255,6 +2287,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 1,
          "requiredJobs": [
             {
                "id": "kelp-welcome",
@@ -2317,6 +2350,7 @@
          "date": {
             "added": 1.32914936623526E+17
          },
+         "topicComplexity": 1,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -2383,6 +2417,7 @@
          "date": {
             "added": 1.3294107995602E+17
          },
+         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "arctic-disappearing-act",
@@ -2477,6 +2512,7 @@
          "date": {
             "added": 1.3294107995602E+17
          },
+         "topicComplexity": 1,
          "requiredJobs": [
             {
                "id": "arctic-missing-whale",
@@ -2502,6 +2538,12 @@
                "id": "ROVScanner",
                "date": {
                   "added": 1.32953898419312E+17
+               }
+            },
+            {
+               "id": "Microscope",
+               "date": {
+                  "added": 1.33311514440551E+17
                }
             }
          ],
@@ -2539,6 +2581,7 @@
          "date": {
             "added": 1.3294107995602E+17
          },
+         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "arctic-stationary-survival",
@@ -2590,7 +2633,8 @@
             {
                "id": "scanSponge",
                "date": {
-                  "added": 1.3294107995602E+17
+                  "added": 1.3294107995602E+17,
+                  "deprecated": 1.33311514440551E+17
                },
                "category": "Scan_Count"
             },
@@ -2685,6 +2729,7 @@
          "date": {
             "added": 1.3294107995602E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "arctic-underneath",
@@ -2740,6 +2785,7 @@
          "date": {
             "added": 1.3294107995602E+17
          },
+         "topicComplexity": 1,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -2828,6 +2874,7 @@
          "date": {
             "added": 1.3295916222049E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "turtle-danger2",
@@ -2904,6 +2951,7 @@
          "date": {
             "added": 1.3295916222049E+17
          },
+         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "turtle-danger2",
@@ -2953,6 +3001,7 @@
          "date": {
             "added": 1.3305916268445E+17
          },
+         "topicComplexity": 1,
          "requiredJobs": [
             {
                "id": "arctic-seal-habbits",
@@ -3018,6 +3067,7 @@
          "date": {
             "added": 1.3305916268445E+17
          },
+         "topicComplexity": 1,
          "requiredJobs": [
             {
                "id": "arctic-salmon-monitoring",
@@ -3087,6 +3137,7 @@
          "date": {
             "added": 1.3305916268445E+17
          },
+         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "arctic-in-ice",
@@ -3143,6 +3194,7 @@
          "date": {
             "added": 1.3305916268445E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "arctic-in-ice",
@@ -3326,6 +3378,7 @@
          "date": {
             "added": 1.3305916268445E+17
          },
+         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "bayou-boom-cause",
@@ -3395,6 +3448,7 @@
          "date": {
             "added": 1.3305916268445E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -3445,6 +3499,7 @@
          "date": {
             "added": 1.3305916268445E+17
          },
+         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "bayou-alt-energy",
@@ -3503,7 +3558,8 @@
             {
                "id": "Reproduction",
                "date": {
-                  "added": 1.3305916268445E+17
+                  "added": 1.3305916268445E+17,
+                  "deprecated": 1.33311514440551E+17
                },
                "category": "Experiment"
             },
@@ -3551,6 +3607,7 @@
          "date": {
             "added": 1.3305916268445E+17
          },
+         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "coral-much-algae",
@@ -3634,6 +3691,7 @@
          "date": {
             "added": 1.33067919669553E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -3717,6 +3775,7 @@
          "date": {
             "added": 1.33080912981555E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "above-n-below",
@@ -3810,6 +3869,7 @@
          "date": {
             "added": 1.33111006512628E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "bayou-shrimp-yields",
@@ -3905,6 +3965,7 @@
          "date": {
             "added": 1.33111006512628E+17
          },
+         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "bayou-blue-waters",
@@ -3965,6 +4026,13 @@
                "id": "reportBack",
                "date": {
                   "added": 1.33111006512628E+17
+               },
+               "category": "Argue"
+            },
+            {
+               "id": "scanProbe",
+               "date": {
+                  "added": 1.33311514440551E+17
                },
                "category": "Argue"
             }

--- a/DBExport.json
+++ b/DBExport.json
@@ -6,7 +6,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 1,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -20,7 +19,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 0,
-            "argumentation": 2
+            "argumentation": 2,
+            "topicComplexity": 1
          },
          "tasks": [
             {
@@ -66,7 +66,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "arctic-disappearing-act",
@@ -99,7 +98,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 0,
-            "argumentation": 5
+            "argumentation": 5,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -137,7 +137,6 @@
             "added": 1.32914936623526E+17,
             "deprecated": 1.33138730177673E+17
          },
-         "topicComplexity": 0,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -145,7 +144,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 0,
-            "argumentation": 0
+            "argumentation": 0,
+            "topicComplexity": 0
          },
          "tasks": [
             {
@@ -179,7 +179,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 1,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -187,7 +186,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 0,
-            "argumentation": 2
+            "argumentation": 2,
+            "topicComplexity": 1
          },
          "tasks": [
             {
@@ -242,7 +242,6 @@
             "added": 1.32914936623526E+17,
             "deprecated": 1.3295916222049E+17
          },
-         "topicComplexity": 0,
          "requiredJobs": [
             {
                "id": "turtle-danger2",
@@ -278,7 +277,8 @@
          "difficulties": {
             "experimentation": 3,
             "modeling": 4,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 0
          },
          "tasks": [
             {
@@ -333,7 +333,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "bayou-shrimp-tastrophe",
@@ -408,7 +407,8 @@
          "difficulties": {
             "experimentation": 3,
             "modeling": 3,
-            "argumentation": 4
+            "argumentation": 4,
+            "topicComplexity": 3
          },
          "tasks": [
             {
@@ -482,7 +482,6 @@
             "added": 1.32914936623526E+17,
             "deprecated": 1.3295916222049E+17
          },
-         "topicComplexity": 0,
          "requiredJobs": [
             {
                "id": "turtle-danger2",
@@ -511,7 +510,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 4,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 0
          },
          "tasks": [
             {
@@ -540,7 +540,6 @@
             "added": 1.32914936623526E+17,
             "deprecated": 1.33111006512628E+17
          },
-         "topicComplexity": 0,
          "requiredJobs": [
             {
                "id": "bayou-save-our-shrimp",
@@ -555,7 +554,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 0,
-            "argumentation": 0
+            "argumentation": 0,
+            "topicComplexity": 0
          },
          "tasks": [
             {
@@ -583,7 +583,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "bayou-save-our-shrimp",
@@ -652,7 +651,8 @@
          "difficulties": {
             "experimentation": 5,
             "modeling": 5,
-            "argumentation": 5
+            "argumentation": 5,
+            "topicComplexity": 3
          },
          "tasks": [
             {
@@ -689,7 +689,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "displaced-reef",
@@ -715,7 +714,8 @@
          "difficulties": {
             "experimentation": 1,
             "modeling": 1,
-            "argumentation": 4
+            "argumentation": 4,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -770,7 +770,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "turtle-danger",
@@ -832,7 +831,8 @@
          "difficulties": {
             "experimentation": 4,
             "modeling": 3,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 3
          },
          "tasks": [
             {
@@ -878,7 +878,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "coral-stressed",
@@ -934,7 +933,8 @@
          "difficulties": {
             "experimentation": 3,
             "modeling": 3,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -1034,7 +1034,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 0,
          "requiredJobs": [
             {
                "id": "coral-casting-shade",
@@ -1048,7 +1047,8 @@
          "difficulties": {
             "experimentation": 2,
             "modeling": 0,
-            "argumentation": 2
+            "argumentation": 2,
+            "topicComplexity": 0
          },
          "tasks": [
             {
@@ -1076,7 +1076,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "coral-turtle-population",
@@ -1108,7 +1107,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 0,
-            "argumentation": 4
+            "argumentation": 4,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -1154,7 +1154,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -1186,7 +1185,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 4,
-            "argumentation": 3
+            "argumentation": 3,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -1232,7 +1232,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "coral-lionfish-conspiracy",
@@ -1301,7 +1300,8 @@
          "difficulties": {
             "experimentation": 5,
             "modeling": 5,
-            "argumentation": 5
+            "argumentation": 5,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -1428,7 +1428,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 1,
          "requiredJobs": [
             {
                "id": "coral-fake-fix",
@@ -1448,7 +1447,8 @@
          "difficulties": {
             "experimentation": 1,
             "modeling": 0,
-            "argumentation": 3
+            "argumentation": 3,
+            "topicComplexity": 1
          },
          "tasks": [
             {
@@ -1494,7 +1494,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "coral-fake-fix",
@@ -1526,7 +1525,8 @@
          "difficulties": {
             "experimentation": 3,
             "modeling": 3,
-            "argumentation": 3
+            "argumentation": 3,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -1590,7 +1590,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 1,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -1622,7 +1621,8 @@
          "difficulties": {
             "experimentation": 2,
             "modeling": 0,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 1
          },
          "tasks": [
             {
@@ -1667,7 +1667,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -1699,7 +1698,8 @@
          "difficulties": {
             "experimentation": 2,
             "modeling": 0,
-            "argumentation": 4
+            "argumentation": 4,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -1736,7 +1736,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 0,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -1744,7 +1743,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 0,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 0
          },
          "tasks": [
             {
@@ -1789,7 +1789,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 1,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -1803,7 +1802,8 @@
          "difficulties": {
             "experimentation": 1,
             "modeling": 1,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 1
          },
          "tasks": [
             {
@@ -1850,7 +1850,6 @@
             "added": 1.32914936623526E+17,
             "deprecated": 1.33138730177673E+17
          },
-         "topicComplexity": 0,
          "requiredJobs": [
             {
                "id": "coral-urchin-friends",
@@ -1865,7 +1864,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 0,
-            "argumentation": 0
+            "argumentation": 0,
+            "topicComplexity": 0
          },
          "tasks": [
             {
@@ -1911,7 +1911,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 1,
          "requiredJobs": [
             {
                "id": "kelp-welcome",
@@ -1925,7 +1924,8 @@
          "difficulties": {
             "experimentation": 1,
             "modeling": 0,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 1
          },
          "tasks": [
             {
@@ -1962,7 +1962,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 1,
          "requiredJobs": [
             {
                "id": "kelp-shop-welcome",
@@ -1976,7 +1975,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 1,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 1
          },
          "tasks": [
             {
@@ -2004,7 +2004,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "kelp-welcome",
@@ -2042,7 +2041,8 @@
          "difficulties": {
             "experimentation": 2,
             "modeling": 0,
-            "argumentation": 2
+            "argumentation": 2,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -2088,7 +2088,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "kelp-mussel-fest",
@@ -2114,7 +2113,8 @@
          "difficulties": {
             "experimentation": 2,
             "modeling": 0,
-            "argumentation": 3
+            "argumentation": 3,
+            "topicComplexity": 3
          },
          "tasks": [
             {
@@ -2151,7 +2151,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "kelp-start-refuge",
@@ -2183,7 +2182,8 @@
          "difficulties": {
             "experimentation": 4,
             "modeling": 3,
-            "argumentation": 3
+            "argumentation": 3,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -2274,7 +2274,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "kelp-refuge-failure",
@@ -2294,7 +2293,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 4,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -2322,7 +2322,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "kelp-urchin-barren-predict",
@@ -2342,7 +2341,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 4,
-            "argumentation": 2
+            "argumentation": 2,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -2370,7 +2370,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "kelp-welcome",
@@ -2402,7 +2401,8 @@
          "difficulties": {
             "experimentation": 2,
             "modeling": 0,
-            "argumentation": 4
+            "argumentation": 4,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -2439,7 +2439,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 1,
          "requiredJobs": [
             {
                "id": "kelp-urchin-barren-viz",
@@ -2459,7 +2458,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 3,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 1
          },
          "tasks": [
             {
@@ -2487,7 +2487,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 1,
          "requiredJobs": [
             {
                "id": "kelp-welcome",
@@ -2519,7 +2518,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 1,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 1
          },
          "tasks": [
             {
@@ -2574,7 +2574,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 1,
          "requiredJobs": [
             {
                "id": "kelp-welcome",
@@ -2606,7 +2605,8 @@
          "difficulties": {
             "experimentation": 3,
             "modeling": 0,
-            "argumentation": 4
+            "argumentation": 4,
+            "topicComplexity": 1
          },
          "tasks": [
             {
@@ -2643,7 +2643,6 @@
          "date": {
             "added": 1.32914936623526E+17
          },
-         "topicComplexity": 1,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -2651,7 +2650,8 @@
          "difficulties": {
             "experimentation": 1,
             "modeling": 0,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 1
          },
          "tasks": [
             {
@@ -2724,7 +2724,6 @@
          "date": {
             "added": 1.3294107995602E+17
          },
-         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "arctic-disappearing-act",
@@ -2774,7 +2773,8 @@
          "difficulties": {
             "experimentation": 1,
             "modeling": 0,
-            "argumentation": 5
+            "argumentation": 5,
+            "topicComplexity": 3
          },
          "tasks": [
             {
@@ -2829,7 +2829,6 @@
          "date": {
             "added": 1.3294107995602E+17
          },
-         "topicComplexity": 1,
          "requiredJobs": [
             {
                "id": "arctic-missing-whale",
@@ -2867,7 +2866,8 @@
          "difficulties": {
             "experimentation": 2,
             "modeling": 2,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 1
          },
          "tasks": [
             {
@@ -2904,7 +2904,6 @@
          "date": {
             "added": 1.3294107995602E+17
          },
-         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "arctic-stationary-survival",
@@ -2950,7 +2949,8 @@
          "difficulties": {
             "experimentation": 3,
             "modeling": 0,
-            "argumentation": 5
+            "argumentation": 5,
+            "topicComplexity": 3
          },
          "tasks": [
             {
@@ -3078,7 +3078,6 @@
          "date": {
             "added": 1.3294107995602E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "arctic-underneath",
@@ -3110,7 +3109,8 @@
          "difficulties": {
             "experimentation": 1,
             "modeling": 2,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -3138,7 +3138,6 @@
          "date": {
             "added": 1.3294107995602E+17
          },
-         "topicComplexity": 1,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -3152,7 +3151,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 0,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 1
          },
          "tasks": [
             {
@@ -3180,7 +3180,6 @@
          "date": {
             "added": 1.32953898419312E+17
          },
-         "topicComplexity": 0,
          "requiredJobs": [
             {
                "id": "kelp-bull-kelp-forest",
@@ -3194,7 +3193,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 0,
-            "argumentation": 0
+            "argumentation": 0,
+            "topicComplexity": 0
          },
          "tasks": [
             {
@@ -3240,7 +3240,6 @@
          "date": {
             "added": 1.3295916222049E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "turtle-danger2",
@@ -3272,7 +3271,8 @@
          "difficulties": {
             "experimentation": 3,
             "modeling": 4,
-            "argumentation": 3
+            "argumentation": 3,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -3327,7 +3327,6 @@
          "date": {
             "added": 1.3295916222049E+17
          },
-         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "turtle-danger2",
@@ -3353,7 +3352,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 4,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 3
          },
          "tasks": [
             {
@@ -3381,7 +3381,6 @@
          "date": {
             "added": 1.3305916268445E+17
          },
-         "topicComplexity": 1,
          "requiredJobs": [
             {
                "id": "arctic-seal-habbits",
@@ -3402,7 +3401,8 @@
          "difficulties": {
             "experimentation": 2,
             "modeling": 1,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 1
          },
          "tasks": [
             {
@@ -3457,7 +3457,6 @@
          "date": {
             "added": 1.3305916268445E+17
          },
-         "topicComplexity": 1,
          "requiredJobs": [
             {
                "id": "arctic-salmon-monitoring",
@@ -3489,7 +3488,8 @@
          "difficulties": {
             "experimentation": 1,
             "modeling": 0,
-            "argumentation": 2
+            "argumentation": 2,
+            "topicComplexity": 1
          },
          "tasks": [
             {
@@ -3535,7 +3535,6 @@
          "date": {
             "added": 1.3305916268445E+17
          },
-         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "arctic-in-ice",
@@ -3561,7 +3560,8 @@
          "difficulties": {
             "experimentation": 3,
             "modeling": 0,
-            "argumentation": 4
+            "argumentation": 4,
+            "topicComplexity": 3
          },
          "tasks": [
             {
@@ -3598,7 +3598,6 @@
          "date": {
             "added": 1.3305916268445E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "arctic-in-ice",
@@ -3642,7 +3641,8 @@
          "difficulties": {
             "experimentation": 1,
             "modeling": 3,
-            "argumentation": 4
+            "argumentation": 4,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -3679,7 +3679,6 @@
          "date": {
             "added": 1.3305916268445E+17
          },
-         "topicComplexity": 0,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -3699,7 +3698,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 0,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 0
          },
          "tasks": [
             {
@@ -3728,7 +3728,6 @@
             "added": 1.3305916268445E+17,
             "deprecated": 1.33080912981555E+17
          },
-         "topicComplexity": 0,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -3754,7 +3753,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 0,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 0
          },
          "tasks": [
             {
@@ -3804,7 +3804,6 @@
          "date": {
             "added": 1.3305916268445E+17
          },
-         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "bayou-boom-cause",
@@ -3836,7 +3835,8 @@
          "difficulties": {
             "experimentation": 1,
             "modeling": 1,
-            "argumentation": 3
+            "argumentation": 3,
+            "topicComplexity": 3
          },
          "tasks": [
             {
@@ -3882,7 +3882,6 @@
          "date": {
             "added": 1.3305916268445E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -3902,7 +3901,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 0,
-            "argumentation": 3
+            "argumentation": 3,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -3939,7 +3939,6 @@
          "date": {
             "added": 1.3305916268445E+17
          },
-         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "bayou-alt-energy",
@@ -3971,7 +3970,8 @@
          "difficulties": {
             "experimentation": 4,
             "modeling": 0,
-            "argumentation": 3
+            "argumentation": 3,
+            "topicComplexity": 3
          },
          "tasks": [
             {
@@ -4028,7 +4028,6 @@
             "added": 1.3305916268445E+17,
             "deprecated": 1.33138730940424E+17
          },
-         "topicComplexity": 0,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -4036,7 +4035,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 0,
-            "argumentation": 0
+            "argumentation": 0,
+            "topicComplexity": 0
          },
          "tasks": [
             {
@@ -4062,7 +4062,6 @@
          "date": {
             "added": 1.3305916268445E+17
          },
-         "topicComplexity": 3,
          "requiredJobs": [
             {
                "id": "coral-much-algae",
@@ -4094,7 +4093,8 @@
          "difficulties": {
             "experimentation": 3,
             "modeling": 3,
-            "argumentation": 2
+            "argumentation": 2,
+            "topicComplexity": 3
          },
          "tasks": [
             {
@@ -4158,7 +4158,6 @@
          "date": {
             "added": 1.33067919669553E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -4184,7 +4183,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 0,
-            "argumentation": 2
+            "argumentation": 2,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -4256,7 +4256,6 @@
          "date": {
             "added": 1.33080912981555E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "above-n-below",
@@ -4312,7 +4311,8 @@
          "difficulties": {
             "experimentation": 5,
             "modeling": 4,
-            "argumentation": 4
+            "argumentation": 4,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -4358,7 +4358,6 @@
          "date": {
             "added": 1.33111006512628E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "bayou-shrimp-yields",
@@ -4402,7 +4401,8 @@
          "difficulties": {
             "experimentation": 5,
             "modeling": 0,
-            "argumentation": 1
+            "argumentation": 1,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -4466,7 +4466,6 @@
          "date": {
             "added": 1.33111006512628E+17
          },
-         "topicComplexity": 2,
          "requiredJobs": [
             {
                "id": "bayou-blue-waters",
@@ -4492,7 +4491,8 @@
          "difficulties": {
             "experimentation": 3,
             "modeling": 0,
-            "argumentation": 3
+            "argumentation": 3,
+            "topicComplexity": 2
          },
          "tasks": [
             {
@@ -4556,7 +4556,6 @@
          "date": {
             "added": 1.33111006512628E+17
          },
-         "topicComplexity": 0,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -4576,7 +4575,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 0,
-            "argumentation": 3
+            "argumentation": 3,
+            "topicComplexity": 0
          },
          "tasks": [
             {
@@ -4604,7 +4604,6 @@
          "date": {
             "added": 1.33138730177673E+17
          },
-         "topicComplexity": 0,
          "requiredJobs": [
          ],
          "requiredUpgrades": [
@@ -4612,7 +4611,8 @@
          "difficulties": {
             "experimentation": 0,
             "modeling": 2,
-            "argumentation": 4
+            "argumentation": 4,
+            "topicComplexity": 0
          },
          "tasks": [
             {


### PR DESCRIPTION
- Jobs now have a "topic complexity" int (0 to 3), available in the editor and passed through to DBExport
- Tasks now have "task complexity" and "scaffolding complexity" ints (0 to 3), available in the editor and passed through to DBExport
- DBExport now includes the prerequisite tasks for each task
- DBExport now includes AcquireBestiaryEntry, AcquireFact, and UpgradeFact steps